### PR TITLE
Add simple CuTe mat-transpose implementations

### DIFF
--- a/kernels/mat-transpose/README.md
+++ b/kernels/mat-transpose/README.md
@@ -28,160 +28,457 @@ python3 mat_transpose.py
 输出:
 
 ```bash
-------------------------------------------------------------------------------------------------------------------------
-                                                  S=1024, K=1024
-                  out_original: [0.2706067, 1.89055979, 0.62714416], validate False, time:0.00007796ms
-               out_f32_col2row: [0.2706067, 0.62714416, 1.89055979], validate True , time:0.03732634ms
-               out_f32_row2col: [0.2706067, 0.62714416, 1.89055979], validate True , time:0.03055906ms
-           out_f32_col2row(2d): [0.2706067, 0.62714416, 1.89055979], validate True , time:0.02096868ms
-           out_f32_row2col(2d): [0.2706067, 0.62714416, 1.89055979], validate True , time:0.03112197ms
-             out_f32_diagnonal: [0.2706067, 0.62714416, 1.89055979], validate True , time:0.02037907ms
-             out_f32x4_col2row: [0.2706067, 0.62714416, 1.89055979], validate True , time:0.06107259ms
-             out_f32x4_row2col: [0.2706067, 0.62714416, 1.89055979], validate True , time:0.02692676ms
-         out_f32x4_col2row(2d): [0.2706067, 0.62714416, 1.89055979], validate True , time:0.03207874ms
-         out_f32x4_row2col(2d): [0.2706067, 0.62714416, 1.89055979], validate True , time:0.01719213ms
-      out_f32x4_shared_col2row: [0.2706067, 0.62714416, 1.89055979], validate True , time:0.01326251ms
-      out_f32x4_shared_row2col: [0.2706067, 0.62714416, 1.89055979], validate True , time:0.02352262ms
-  out_f32x4_shared_bcf_col2row: [0.2706067, 0.62714416, 1.89055979], validate True , time:0.01917195ms
-  out_f32x4_shared_bcf_row2col: [0.2706067, 0.62714416, 1.89055979], validate True , time:0.01389265ms
-                    out_f32_th: [0.2706067, 0.62714416, 1.89055979], validate True , time:0.05057526ms
-------------------------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------------------------
-                                                  S=1024, K=2048
-                  out_original: [0.1013972, 0.10635406, 0.45091254], validate False, time:0.00007367ms
-               out_f32_col2row: [0.1013972, 0.45091254, 0.10635406], validate True , time:0.11233115ms
-               out_f32_row2col: [0.1013972, 0.45091254, 0.10635406], validate True , time:0.05733228ms
-           out_f32_col2row(2d): [0.1013972, 0.45091254, 0.10635406], validate True , time:0.04851723ms
-           out_f32_row2col(2d): [0.1013972, 0.45091254, 0.10635406], validate True , time:0.05224919ms
-             out_f32x4_col2row: [0.1013972, 0.45091254, 0.10635406], validate True , time:0.10379744ms
-             out_f32x4_row2col: [0.1013972, 0.45091254, 0.10635406], validate True , time:0.05431175ms
-         out_f32x4_col2row(2d): [0.1013972, 0.45091254, 0.10635406], validate True , time:0.05774999ms
-         out_f32x4_row2col(2d): [0.1013972, 0.45091254, 0.10635406], validate True , time:0.03115702ms
-      out_f32x4_shared_col2row: [0.1013972, 0.45091254, 0.10635406], validate True , time:0.03814983ms
-      out_f32x4_shared_row2col: [0.1013972, 0.45091254, 0.10635406], validate True , time:0.03473568ms
-  out_f32x4_shared_bcf_col2row: [0.1013972, 0.45091254, 0.10635406], validate True , time:0.03495407ms
-  out_f32x4_shared_bcf_row2col: [0.1013972, 0.45091254, 0.10635406], validate True , time:0.03433728ms
-                    out_f32_th: [0.1013972, 0.45091254, 0.10635406], validate True , time:0.08867288ms
-------------------------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------------------------
-                                                  S=1024, K=4096
-                  out_original: [1.78550363, -1.60489535, -0.16560346], validate False, time:0.00007296ms
-               out_f32_col2row: [1.78550363, -0.16560346, -1.60489535], validate True , time:0.19823909ms
-               out_f32_row2col: [1.78550363, -0.16560346, -1.60489535], validate True , time:0.11195445ms
-           out_f32_col2row(2d): [1.78550363, -0.16560346, -1.60489535], validate True , time:0.09996772ms
-           out_f32_row2col(2d): [1.78550363, -0.16560346, -1.60489535], validate True , time:0.09864736ms
-             out_f32x4_col2row: [1.78550363, -0.16560346, -1.60489535], validate True , time:0.19718719ms
-             out_f32x4_row2col: [1.78550363, -0.16560346, -1.60489535], validate True , time:0.11092091ms
-         out_f32x4_col2row(2d): [1.78550363, -0.16560346, -1.60489535], validate True , time:0.10105634ms
-         out_f32x4_row2col(2d): [1.78550363, -0.16560346, -1.60489535], validate True , time:0.06530714ms
-      out_f32x4_shared_col2row: [1.78550363, -0.16560346, -1.60489535], validate True , time:0.06287837ms
-      out_f32x4_shared_row2col: [1.78550363, -0.16560346, -1.60489535], validate True , time:0.07055283ms
-  out_f32x4_shared_bcf_col2row: [1.78550363, -0.16560346, -1.60489535], validate True , time:0.06612253ms
-  out_f32x4_shared_bcf_row2col: [1.78550363, -0.16560346, -1.60489535], validate True , time:0.06411195ms
-                    out_f32_th: [1.78550363, -0.16560346, -1.60489535], validate True , time:0.17973542ms
-------------------------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------------------------
-                                                  S=2048, K=1024
-                  out_original: [-0.96589017, -0.53940338, 1.51841831], validate False, time:0.00007153ms
-               out_f32_col2row: [-0.96589017, 1.51841831, -0.53940338], validate True , time:0.10408664ms
-               out_f32_row2col: [-0.96589017, 1.51841831, -0.53940338], validate True , time:0.05784106ms
-           out_f32_col2row(2d): [-0.96589017, 1.51841831, -0.53940338], validate True , time:0.04911971ms
-           out_f32_row2col(2d): [-0.96589017, 1.51841831, -0.53940338], validate True , time:0.04792857ms
-             out_f32x4_col2row: [-0.96589017, 1.51841831, -0.53940338], validate True , time:0.15571523ms
-             out_f32x4_row2col: [-0.96589017, 1.51841831, -0.53940338], validate True , time:0.07688594ms
-         out_f32x4_col2row(2d): [-0.96589017, 1.51841831, -0.53940338], validate True , time:0.05413485ms
-         out_f32x4_row2col(2d): [-0.96589017, 1.51841831, -0.53940338], validate True , time:0.03497577ms
-      out_f32x4_shared_col2row: [-0.96589017, 1.51841831, -0.53940338], validate True , time:0.04818010ms
-      out_f32x4_shared_row2col: [-0.96589017, 1.51841831, -0.53940338], validate True , time:0.05148292ms
-  out_f32x4_shared_bcf_col2row: [-0.96589017, 1.51841831, -0.53940338], validate True , time:0.04849076ms
-  out_f32x4_shared_bcf_row2col: [-0.96589017, 1.51841831, -0.53940338], validate True , time:0.03030324ms
-                    out_f32_th: [-0.96589017, 1.51841831, -0.53940338], validate True , time:0.09853792ms
-------------------------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------------------------
-                                                  S=2048, K=2048
-                  out_original: [0.66138971, 0.43854904, -1.19618118], validate False, time:0.00007439ms
-               out_f32_col2row: [0.66138971, -1.19618118, 0.43854904], validate True , time:0.24223709ms
-               out_f32_row2col: [0.66138971, -1.19618118, 0.43854904], validate True , time:0.15707016ms
-           out_f32_col2row(2d): [0.66138971, -1.19618118, 0.43854904], validate True , time:0.09814286ms
-           out_f32_row2col(2d): [0.66138971, -1.19618118, 0.43854904], validate True , time:0.13747311ms
-             out_f32_diagnonal: [0.66138971, -1.19618118, 0.43854904], validate True , time:0.08852434ms
-             out_f32x4_col2row: [0.66138971, -1.19618118, 0.43854904], validate True , time:0.26274681ms
-             out_f32x4_row2col: [0.66138971, -1.19618118, 0.43854904], validate True , time:0.12002778ms
-         out_f32x4_col2row(2d): [0.66138971, -1.19618118, 0.43854904], validate True , time:0.15025878ms
-         out_f32x4_row2col(2d): [0.66138971, -1.19618118, 0.43854904], validate True , time:0.07008457ms
-      out_f32x4_shared_col2row: [0.66138971, -1.19618118, 0.43854904], validate True , time:0.07605863ms
-      out_f32x4_shared_row2col: [0.66138971, -1.19618118, 0.43854904], validate True , time:0.09375811ms
-  out_f32x4_shared_bcf_col2row: [0.66138971, -1.19618118, 0.43854904], validate True , time:0.07940960ms
-  out_f32x4_shared_bcf_row2col: [0.66138971, -1.19618118, 0.43854904], validate True , time:0.07159257ms
-                    out_f32_th: [0.66138971, -1.19618118, 0.43854904], validate True , time:0.25392270ms
-------------------------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------------------------
-                                                  S=2048, K=4096
-                  out_original: [0.21140628, 0.86610204, -0.61084032], validate False, time:0.00007534ms
-               out_f32_col2row: [0.21140628, -0.61084032, 0.86610204], validate True , time:0.51111245ms
-               out_f32_row2col: [0.21140628, -0.61084032, 0.86610204], validate True , time:0.29512668ms
-           out_f32_col2row(2d): [0.21140628, -0.61084032, 0.86610204], validate True , time:0.25763965ms
-           out_f32_row2col(2d): [0.21140628, -0.61084032, 0.86610204], validate True , time:0.25509524ms
-             out_f32x4_col2row: [0.21140628, -0.61084032, 0.86610204], validate True , time:0.47753954ms
-             out_f32x4_row2col: [0.21140628, -0.61084032, 0.86610204], validate True , time:0.27053690ms
-         out_f32x4_col2row(2d): [0.21140628, -0.61084032, 0.86610204], validate True , time:0.26033616ms
-         out_f32x4_row2col(2d): [0.21140628, -0.61084032, 0.86610204], validate True , time:0.16601658ms
-      out_f32x4_shared_col2row: [0.21140628, -0.61084032, 0.86610204], validate True , time:0.14935517ms
-      out_f32x4_shared_row2col: [0.21140628, -0.61084032, 0.86610204], validate True , time:0.17617536ms
-  out_f32x4_shared_bcf_col2row: [0.21140628, -0.61084032, 0.86610204], validate True , time:0.14183927ms
-  out_f32x4_shared_bcf_row2col: [0.21140628, -0.61084032, 0.86610204], validate True , time:0.17589092ms
-                    out_f32_th: [0.21140628, -0.61084032, 0.86610204], validate True , time:0.43119144ms
-------------------------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------------------------
-                                                  S=4096, K=1024
-                  out_original: [-0.33594334, -0.13206008, 0.8452214], validate False, time:0.00007868ms
-               out_f32_col2row: [-0.33594334, 0.8452214, -0.13206008], validate True , time:0.26727128ms
-               out_f32_row2col: [-0.33594334, 0.8452214, -0.13206008], validate True , time:0.17777562ms
-           out_f32_col2row(2d): [-0.33594334, 0.8452214, -0.13206008], validate True , time:0.09764647ms
-           out_f32_row2col(2d): [-0.33594334, 0.8452214, -0.13206008], validate True , time:0.13735604ms
-             out_f32x4_col2row: [-0.33594334, 0.8452214, -0.13206008], validate True , time:0.25628328ms
-             out_f32x4_row2col: [-0.33594334, 0.8452214, -0.13206008], validate True , time:0.15057874ms
-         out_f32x4_col2row(2d): [-0.33594334, 0.8452214, -0.13206008], validate True , time:0.12607431ms
-         out_f32x4_row2col(2d): [-0.33594334, 0.8452214, -0.13206008], validate True , time:0.09281611ms
-      out_f32x4_shared_col2row: [-0.33594334, 0.8452214, -0.13206008], validate True , time:0.07143378ms
-      out_f32x4_shared_row2col: [-0.33594334, 0.8452214, -0.13206008], validate True , time:0.08804989ms
-  out_f32x4_shared_bcf_col2row: [-0.33594334, 0.8452214, -0.13206008], validate True , time:0.09320903ms
-  out_f32x4_shared_bcf_row2col: [-0.33594334, 0.8452214, -0.13206008], validate True , time:0.07376838ms
-                    out_f32_th: [-0.33594334, 0.8452214, -0.13206008], validate True , time:0.25272131ms
-------------------------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------------------------
-                                                  S=4096, K=2048
-                  out_original: [1.44601941, 1.46612203, -2.00953078], validate False, time:0.00007796ms
-               out_f32_col2row: [1.44601941, -2.00953078, 1.46612203], validate True , time:0.51826644ms
-               out_f32_row2col: [1.44601941, -2.00953078, 1.46612203], validate True , time:0.31751609ms
-           out_f32_col2row(2d): [1.44601941, -2.00953078, 1.46612203], validate True , time:0.26685858ms
-           out_f32_row2col(2d): [1.44601941, -2.00953078, 1.46612203], validate True , time:0.18520737ms
-             out_f32x4_col2row: [1.44601941, -2.00953078, 1.46612203], validate True , time:0.29121876ms
-             out_f32x4_row2col: [1.44601941, -2.00953078, 1.46612203], validate True , time:0.16650081ms
-         out_f32x4_col2row(2d): [1.44601941, -2.00953078, 1.46612203], validate True , time:0.14630580ms
-         out_f32x4_row2col(2d): [1.44601941, -2.00953078, 1.46612203], validate True , time:0.09408069ms
-      out_f32x4_shared_col2row: [1.44601941, -2.00953078, 1.46612203], validate True , time:0.09475493ms
-      out_f32x4_shared_row2col: [1.44601941, -2.00953078, 1.46612203], validate True , time:0.09508491ms
-  out_f32x4_shared_bcf_col2row: [1.44601941, -2.00953078, 1.46612203], validate True , time:0.09532118ms
-  out_f32x4_shared_bcf_row2col: [1.44601941, -2.00953078, 1.46612203], validate True , time:0.09467864ms
-                    out_f32_th: [1.44601941, -2.00953078, 1.46612203], validate True , time:0.26716113ms
-------------------------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------------------------
-                                                  S=4096, K=4096
-                  out_original: [-1.07092094, -1.13755226, 0.99070781], validate False, time:0.00007606ms
-               out_f32_col2row: [-1.07092094, 0.99070781, -1.13755226], validate True , time:0.75331712ms
-               out_f32_row2col: [-1.07092094, 0.99070781, -1.13755226], validate True , time:0.52119255ms
-           out_f32_col2row(2d): [-1.07092094, 0.99070781, -1.13755226], validate True , time:0.36621094ms
-           out_f32_row2col(2d): [-1.07092094, 0.99070781, -1.13755226], validate True , time:0.36603284ms
-             out_f32_diagnonal: [-1.07092094, 0.99070781, -1.13755226], validate True , time:0.37416911ms
-             out_f32x4_col2row: [-1.07092094, 0.99070781, -1.13755226], validate True , time:0.96249247ms
-             out_f32x4_row2col: [-1.07092094, 0.99070781, -1.13755226], validate True , time:0.56916833ms
-         out_f32x4_col2row(2d): [-1.07092094, 0.99070781, -1.13755226], validate True , time:0.48158646ms
-         out_f32x4_row2col(2d): [-1.07092094, 0.99070781, -1.13755226], validate True , time:0.30216074ms
-      out_f32x4_shared_col2row: [-1.07092094, 0.99070781, -1.13755226], validate True , time:0.32637930ms
-      out_f32x4_shared_row2col: [-1.07092094, 0.99070781, -1.13755226], validate True , time:0.32455182ms
-  out_f32x4_shared_bcf_col2row: [-1.07092094, 0.99070781, -1.13755226], validate True , time:0.30707669ms
-  out_f32x4_shared_bcf_row2col: [-1.07092094, 0.99070781, -1.13755226], validate True , time:0.31853962ms
-                    out_f32_th: [-1.07092094, 0.99070781, -1.13755226], validate True , time:0.91187215ms
-------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------
+                                                       M=1024, N=1024
+                       out_original: [0.0, 1.0, 1024.0], validate False, time:0.00667048ms
+                    out_f32_col2row: [0.0, 1024.0, 1.0], validate True , time:0.01761174ms
+                    out_f32_row2col: [0.0, 1024.0, 1.0], validate True , time:0.01008821ms
+                out_f32_col2row(2d): [0.0, 1024.0, 1.0], validate True , time:0.00852585ms
+                out_f32_row2col(2d): [0.0, 1024.0, 1.0], validate True , time:0.00851846ms
+                  out_f32_diagnonal: [0.0, 1024.0, 1.0], validate True , time:0.00641012ms
+                  out_f32x4_col2row: [0.0, 1024.0, 1.0], validate True , time:0.01742840ms
+                  out_f32x4_row2col: [0.0, 1024.0, 1.0], validate True , time:0.00943899ms
+              out_f32x4_col2row(2d): [0.0, 1024.0, 1.0], validate True , time:0.00987363ms
+              out_f32x4_row2col(2d): [0.0, 1024.0, 1.0], validate True , time:0.00499630ms
+       out_f32x4_shared_col2row(2d): [0.0, 1024.0, 1.0], validate True , time:0.00524426ms
+       out_f32x4_shared_row2col(2d): [0.0, 1024.0, 1.0], validate True , time:0.00670385ms
+   out_f32x4_shared_bcf_col2row(2d): [0.0, 1024.0, 1.0], validate True , time:0.00536251ms
+   out_f32x4_shared_bcf_row2col(2d): [0.0, 1024.0, 1.0], validate True , time:0.00580740ms
+ out_mat_transpose_cute_col2row_reg: [0.0, 1024.0, 1.0], validate True , time:0.00747943ms
+ out_mat_transpose_cute_row2col_reg: [0.0, 1024.0, 1.0], validate True , time:0.00599384ms
+    out_mat_transpose_cute_col_smem: [0.0, 1024.0, 1.0], validate True , time:0.00989509ms
+    out_mat_transpose_cute_row_smem: [0.0, 1024.0, 1.0], validate True , time:0.00534320ms
+out_mat_transpose_cute_col_smem_swizzled: [0.0, 1024.0, 1.0], validate True , time:0.00869393ms
+out_mat_transpose_cute_row_smem_swizzled: [0.0, 1024.0, 1.0], validate True , time:0.00555682ms
+out_mat_transpose_cute_row_cvectorized: [0.0, 1024.0, 1.0], validate True , time:0.00727987ms
+out_mat_transpose_cute_row_rvectorized: [0.0, 1024.0, 1.0], validate True , time:0.00493646ms
+out_mat_transpose_cute_row_cvectorized_swizzled: [0.0, 1024.0, 1.0], validate True , time:0.00592184ms
+out_mat_transpose_cute_row_rvectorized_swizzled: [0.0, 1024.0, 1.0], validate True , time:0.00563526ms
+                         out_f32_th: [0.0, 1024.0, 1.0], validate True , time:0.01460934ms
+                out_f32_th_compiled: [0.0, 1024.0, 1.0], validate True , time:0.03173113ms
+----------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------
+                                                       M=1024, N=2048
+                       out_original: [0.0, 1.0, 2048.0], validate False, time:0.00685191ms
+                    out_f32_col2row: [0.0, 2048.0, 1.0], validate True , time:0.03323030ms
+                    out_f32_row2col: [0.0, 2048.0, 1.0], validate True , time:0.01826382ms
+                out_f32_col2row(2d): [0.0, 2048.0, 1.0], validate True , time:0.01468587ms
+                out_f32_row2col(2d): [0.0, 2048.0, 1.0], validate True , time:0.01467657ms
+                  out_f32x4_col2row: [0.0, 2048.0, 1.0], validate True , time:0.03329539ms
+                  out_f32x4_row2col: [0.0, 2048.0, 1.0], validate True , time:0.01831269ms
+              out_f32x4_col2row(2d): [0.0, 2048.0, 1.0], validate True , time:0.01730418ms
+              out_f32x4_row2col(2d): [0.0, 2048.0, 1.0], validate True , time:0.00699377ms
+       out_f32x4_shared_col2row(2d): [0.0, 2048.0, 1.0], validate True , time:0.00813270ms
+       out_f32x4_shared_row2col(2d): [0.0, 2048.0, 1.0], validate True , time:0.01007080ms
+   out_f32x4_shared_bcf_col2row(2d): [0.0, 2048.0, 1.0], validate True , time:0.00836945ms
+   out_f32x4_shared_bcf_row2col(2d): [0.0, 2048.0, 1.0], validate True , time:0.00849128ms
+ out_mat_transpose_cute_col2row_reg: [0.0, 2048.0, 1.0], validate True , time:0.01324391ms
+ out_mat_transpose_cute_row2col_reg: [0.0, 2048.0, 1.0], validate True , time:0.00926590ms
+    out_mat_transpose_cute_col_smem: [0.0, 2048.0, 1.0], validate True , time:0.01706100ms
+    out_mat_transpose_cute_row_smem: [0.0, 2048.0, 1.0], validate True , time:0.00816727ms
+out_mat_transpose_cute_col_smem_swizzled: [0.0, 2048.0, 1.0], validate True , time:0.01489687ms
+out_mat_transpose_cute_row_smem_swizzled: [0.0, 2048.0, 1.0], validate True , time:0.00876975ms
+out_mat_transpose_cute_row_cvectorized: [0.0, 2048.0, 1.0], validate True , time:0.01191163ms
+out_mat_transpose_cute_row_rvectorized: [0.0, 2048.0, 1.0], validate True , time:0.00748754ms
+out_mat_transpose_cute_row_cvectorized_swizzled: [0.0, 2048.0, 1.0], validate True , time:0.00862432ms
+out_mat_transpose_cute_row_rvectorized_swizzled: [0.0, 2048.0, 1.0], validate True , time:0.00858784ms
+                         out_f32_th: [0.0, 2048.0, 1.0], validate True , time:0.02438354ms
+                out_f32_th_compiled: [0.0, 2048.0, 1.0], validate True , time:0.04902887ms
+----------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------
+                                                       M=1024, N=4096
+                       out_original: [0.0, 1.0, 4096.0], validate False, time:0.01132798ms
+                    out_f32_col2row: [0.0, 4096.0, 1.0], validate True , time:0.06182218ms
+                    out_f32_row2col: [0.0, 4096.0, 1.0], validate True , time:0.03392482ms
+                out_f32_col2row(2d): [0.0, 4096.0, 1.0], validate True , time:0.02772188ms
+                out_f32_row2col(2d): [0.0, 4096.0, 1.0], validate True , time:0.02774906ms
+                  out_f32x4_col2row: [0.0, 4096.0, 1.0], validate True , time:0.06245613ms
+                  out_f32x4_row2col: [0.0, 4096.0, 1.0], validate True , time:0.03352976ms
+              out_f32x4_col2row(2d): [0.0, 4096.0, 1.0], validate True , time:0.03137302ms
+              out_f32x4_row2col(2d): [0.0, 4096.0, 1.0], validate True , time:0.01143122ms
+       out_f32x4_shared_col2row(2d): [0.0, 4096.0, 1.0], validate True , time:0.01373696ms
+       out_f32x4_shared_row2col(2d): [0.0, 4096.0, 1.0], validate True , time:0.01705766ms
+   out_f32x4_shared_bcf_col2row(2d): [0.0, 4096.0, 1.0], validate True , time:0.01421714ms
+   out_f32x4_shared_bcf_row2col(2d): [0.0, 4096.0, 1.0], validate True , time:0.01388431ms
+ out_mat_transpose_cute_col2row_reg: [0.0, 4096.0, 1.0], validate True , time:0.02740574ms
+ out_mat_transpose_cute_row2col_reg: [0.0, 4096.0, 1.0], validate True , time:0.01666737ms
+    out_mat_transpose_cute_col_smem: [0.0, 4096.0, 1.0], validate True , time:0.03182530ms
+    out_mat_transpose_cute_row_smem: [0.0, 4096.0, 1.0], validate True , time:0.01621008ms
+out_mat_transpose_cute_col_smem_swizzled: [0.0, 4096.0, 1.0], validate True , time:0.02744722ms
+out_mat_transpose_cute_row_smem_swizzled: [0.0, 4096.0, 1.0], validate True , time:0.01582789ms
+out_mat_transpose_cute_row_cvectorized: [0.0, 4096.0, 1.0], validate True , time:0.02123284ms
+out_mat_transpose_cute_row_rvectorized: [0.0, 4096.0, 1.0], validate True , time:0.01262116ms
+out_mat_transpose_cute_row_cvectorized_swizzled: [0.0, 4096.0, 1.0], validate True , time:0.01439214ms
+out_mat_transpose_cute_row_rvectorized_swizzled: [0.0, 4096.0, 1.0], validate True , time:0.01478362ms
+                         out_f32_th: [0.0, 4096.0, 1.0], validate True , time:0.04604459ms
+                out_f32_th_compiled: [0.0, 4096.0, 1.0], validate True , time:0.04802442ms
+----------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------
+                                                       M=1024, N=8192
+                       out_original: [0.0, 1.0, 8192.0], validate False, time:0.02622271ms
+                    out_f32_col2row: [0.0, 8192.0, 1.0], validate True , time:0.13227582ms
+                    out_f32_row2col: [0.0, 8192.0, 1.0], validate True , time:0.06796670ms
+                out_f32_col2row(2d): [0.0, 8192.0, 1.0], validate True , time:0.06429243ms
+                out_f32_row2col(2d): [0.0, 8192.0, 1.0], validate True , time:0.06427002ms
+                  out_f32x4_col2row: [0.0, 8192.0, 1.0], validate True , time:0.13971567ms
+                  out_f32x4_row2col: [0.0, 8192.0, 1.0], validate True , time:0.06687403ms
+              out_f32x4_col2row(2d): [0.0, 8192.0, 1.0], validate True , time:0.08264017ms
+              out_f32x4_row2col(2d): [0.0, 8192.0, 1.0], validate True , time:0.02314472ms
+       out_f32x4_shared_col2row(2d): [0.0, 8192.0, 1.0], validate True , time:0.02923679ms
+       out_f32x4_shared_row2col(2d): [0.0, 8192.0, 1.0], validate True , time:0.03703094ms
+   out_f32x4_shared_bcf_col2row(2d): [0.0, 8192.0, 1.0], validate True , time:0.02966428ms
+   out_f32x4_shared_bcf_row2col(2d): [0.0, 8192.0, 1.0], validate True , time:0.03264546ms
+ out_mat_transpose_cute_col2row_reg: [0.0, 8192.0, 1.0], validate True , time:0.05948019ms
+ out_mat_transpose_cute_row2col_reg: [0.0, 8192.0, 1.0], validate True , time:0.04069352ms
+    out_mat_transpose_cute_col_smem: [0.0, 8192.0, 1.0], validate True , time:0.06174302ms
+    out_mat_transpose_cute_row_smem: [0.0, 8192.0, 1.0], validate True , time:0.04106617ms
+out_mat_transpose_cute_col_smem_swizzled: [0.0, 8192.0, 1.0], validate True , time:0.05320787ms
+out_mat_transpose_cute_row_smem_swizzled: [0.0, 8192.0, 1.0], validate True , time:0.03881240ms
+out_mat_transpose_cute_row_cvectorized: [0.0, 8192.0, 1.0], validate True , time:0.04451799ms
+out_mat_transpose_cute_row_rvectorized: [0.0, 8192.0, 1.0], validate True , time:0.02818966ms
+out_mat_transpose_cute_row_cvectorized_swizzled: [0.0, 8192.0, 1.0], validate True , time:0.03275704ms
+out_mat_transpose_cute_row_rvectorized_swizzled: [0.0, 8192.0, 1.0], validate True , time:0.03005648ms
+                         out_f32_th: [0.0, 8192.0, 1.0], validate True , time:0.09130526ms
+                out_f32_th_compiled: [0.0, 8192.0, 1.0], validate True , time:0.04808426ms
+----------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------
+                                                       M=2048, N=1024
+                       out_original: [0.0, 1.0, 1024.0], validate False, time:0.00638318ms
+                    out_f32_col2row: [0.0, 1024.0, 1.0], validate True , time:0.03563547ms
+                    out_f32_row2col: [0.0, 1024.0, 1.0], validate True , time:0.01650119ms
+                out_f32_col2row(2d): [0.0, 1024.0, 1.0], validate True , time:0.01620793ms
+                out_f32_row2col(2d): [0.0, 1024.0, 1.0], validate True , time:0.01620555ms
+                  out_f32x4_col2row: [0.0, 1024.0, 1.0], validate True , time:0.03585052ms
+                  out_f32x4_row2col: [0.0, 1024.0, 1.0], validate True , time:0.01708913ms
+              out_f32x4_col2row(2d): [0.0, 1024.0, 1.0], validate True , time:0.01859522ms
+              out_f32x4_row2col(2d): [0.0, 1024.0, 1.0], validate True , time:0.00708890ms
+       out_f32x4_shared_col2row(2d): [0.0, 1024.0, 1.0], validate True , time:0.00807047ms
+       out_f32x4_shared_row2col(2d): [0.0, 1024.0, 1.0], validate True , time:0.01017618ms
+   out_f32x4_shared_bcf_col2row(2d): [0.0, 1024.0, 1.0], validate True , time:0.00838590ms
+   out_f32x4_shared_bcf_row2col(2d): [0.0, 1024.0, 1.0], validate True , time:0.00867391ms
+ out_mat_transpose_cute_col2row_reg: [0.0, 1024.0, 1.0], validate True , time:0.01354027ms
+ out_mat_transpose_cute_row2col_reg: [0.0, 1024.0, 1.0], validate True , time:0.00928712ms
+    out_mat_transpose_cute_col_smem: [0.0, 1024.0, 1.0], validate True , time:0.01707125ms
+    out_mat_transpose_cute_row_smem: [0.0, 1024.0, 1.0], validate True , time:0.00816989ms
+out_mat_transpose_cute_col_smem_swizzled: [0.0, 1024.0, 1.0], validate True , time:0.01489687ms
+out_mat_transpose_cute_row_smem_swizzled: [0.0, 1024.0, 1.0], validate True , time:0.00876665ms
+out_mat_transpose_cute_row_cvectorized: [0.0, 1024.0, 1.0], validate True , time:0.01165247ms
+out_mat_transpose_cute_row_rvectorized: [0.0, 1024.0, 1.0], validate True , time:0.00741124ms
+out_mat_transpose_cute_row_cvectorized_swizzled: [0.0, 1024.0, 1.0], validate True , time:0.00810361ms
+out_mat_transpose_cute_row_rvectorized_swizzled: [0.0, 1024.0, 1.0], validate True , time:0.00862789ms
+                         out_f32_th: [0.0, 1024.0, 1.0], validate True , time:0.02319264ms
+                out_f32_th_compiled: [0.0, 1024.0, 1.0], validate True , time:0.05861235ms
+----------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------
+                                                       M=2048, N=2048
+                       out_original: [0.0, 1.0, 2048.0], validate False, time:0.01117110ms
+                    out_f32_col2row: [0.0, 2048.0, 1.0], validate True , time:0.06950235ms
+                    out_f32_row2col: [0.0, 2048.0, 1.0], validate True , time:0.03485703ms
+                out_f32_col2row(2d): [0.0, 2048.0, 1.0], validate True , time:0.03005457ms
+                out_f32_row2col(2d): [0.0, 2048.0, 1.0], validate True , time:0.03008485ms
+                  out_f32_diagnonal: [0.0, 2048.0, 1.0], validate True , time:0.01830244ms
+                  out_f32x4_col2row: [0.0, 2048.0, 1.0], validate True , time:0.07024670ms
+                  out_f32x4_row2col: [0.0, 2048.0, 1.0], validate True , time:0.03537869ms
+              out_f32x4_col2row(2d): [0.0, 2048.0, 1.0], validate True , time:0.03516817ms
+              out_f32x4_row2col(2d): [0.0, 2048.0, 1.0], validate True , time:0.01145554ms
+       out_f32x4_shared_col2row(2d): [0.0, 2048.0, 1.0], validate True , time:0.01382899ms
+       out_f32x4_shared_row2col(2d): [0.0, 2048.0, 1.0], validate True , time:0.01729012ms
+   out_f32x4_shared_bcf_col2row(2d): [0.0, 2048.0, 1.0], validate True , time:0.01426935ms
+   out_f32x4_shared_bcf_row2col(2d): [0.0, 2048.0, 1.0], validate True , time:0.01422572ms
+ out_mat_transpose_cute_col2row_reg: [0.0, 2048.0, 1.0], validate True , time:0.02737832ms
+ out_mat_transpose_cute_row2col_reg: [0.0, 2048.0, 1.0], validate True , time:0.01676321ms
+    out_mat_transpose_cute_col_smem: [0.0, 2048.0, 1.0], validate True , time:0.03183579ms
+    out_mat_transpose_cute_row_smem: [0.0, 2048.0, 1.0], validate True , time:0.01636028ms
+out_mat_transpose_cute_col_smem_swizzled: [0.0, 2048.0, 1.0], validate True , time:0.02742934ms
+out_mat_transpose_cute_row_smem_swizzled: [0.0, 2048.0, 1.0], validate True , time:0.01592755ms
+out_mat_transpose_cute_row_cvectorized: [0.0, 2048.0, 1.0], validate True , time:0.02093101ms
+out_mat_transpose_cute_row_rvectorized: [0.0, 2048.0, 1.0], validate True , time:0.01259851ms
+out_mat_transpose_cute_row_cvectorized_swizzled: [0.0, 2048.0, 1.0], validate True , time:0.01370025ms
+out_mat_transpose_cute_row_rvectorized_swizzled: [0.0, 2048.0, 1.0], validate True , time:0.01482153ms
+                         out_f32_th: [0.0, 2048.0, 1.0], validate True , time:0.04773760ms
+                out_f32_th_compiled: [0.0, 2048.0, 1.0], validate True , time:0.05919909ms
+----------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------
+                                                       M=2048, N=4096
+                       out_original: [0.0, 1.0, 4096.0], validate False, time:0.02612376ms
+                    out_f32_col2row: [0.0, 4096.0, 1.0], validate True , time:0.13792729ms
+                    out_f32_row2col: [0.0, 4096.0, 1.0], validate True , time:0.06782484ms
+                out_f32_col2row(2d): [0.0, 4096.0, 1.0], validate True , time:0.06800270ms
+                out_f32_row2col(2d): [0.0, 4096.0, 1.0], validate True , time:0.06801772ms
+                  out_f32x4_col2row: [0.0, 4096.0, 1.0], validate True , time:0.14473867ms
+                  out_f32x4_row2col: [0.0, 4096.0, 1.0], validate True , time:0.06878757ms
+              out_f32x4_col2row(2d): [0.0, 4096.0, 1.0], validate True , time:0.08687305ms
+              out_f32x4_row2col(2d): [0.0, 4096.0, 1.0], validate True , time:0.02311611ms
+       out_f32x4_shared_col2row(2d): [0.0, 4096.0, 1.0], validate True , time:0.02917051ms
+       out_f32x4_shared_row2col(2d): [0.0, 4096.0, 1.0], validate True , time:0.03698635ms
+   out_f32x4_shared_bcf_col2row(2d): [0.0, 4096.0, 1.0], validate True , time:0.02948761ms
+   out_f32x4_shared_bcf_row2col(2d): [0.0, 4096.0, 1.0], validate True , time:0.03269577ms
+ out_mat_transpose_cute_col2row_reg: [0.0, 4096.0, 1.0], validate True , time:0.05988336ms
+ out_mat_transpose_cute_row2col_reg: [0.0, 4096.0, 1.0], validate True , time:0.04102373ms
+    out_mat_transpose_cute_col_smem: [0.0, 4096.0, 1.0], validate True , time:0.06177592ms
+    out_mat_transpose_cute_row_smem: [0.0, 4096.0, 1.0], validate True , time:0.04124475ms
+out_mat_transpose_cute_col_smem_swizzled: [0.0, 4096.0, 1.0], validate True , time:0.05327010ms
+out_mat_transpose_cute_row_smem_swizzled: [0.0, 4096.0, 1.0], validate True , time:0.03905988ms
+out_mat_transpose_cute_row_cvectorized: [0.0, 4096.0, 1.0], validate True , time:0.04370165ms
+out_mat_transpose_cute_row_rvectorized: [0.0, 4096.0, 1.0], validate True , time:0.02813411ms
+out_mat_transpose_cute_row_cvectorized_swizzled: [0.0, 4096.0, 1.0], validate True , time:0.03098154ms
+out_mat_transpose_cute_row_rvectorized_swizzled: [0.0, 4096.0, 1.0], validate True , time:0.03004074ms
+                         out_f32_th: [0.0, 4096.0, 1.0], validate True , time:0.09264803ms
+                out_f32_th_compiled: [0.0, 4096.0, 1.0], validate True , time:0.05882740ms
+----------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------
+                                                       M=2048, N=8192
+                       out_original: [0.0, 1.0, 8192.0], validate False, time:0.04788351ms
+                    out_f32_col2row: [0.0, 8192.0, 1.0], validate True , time:0.26702380ms
+                    out_f32_row2col: [0.0, 8192.0, 1.0], validate True , time:0.12641311ms
+                out_f32_col2row(2d): [0.0, 8192.0, 1.0], validate True , time:0.12766623ms
+                out_f32_row2col(2d): [0.0, 8192.0, 1.0], validate True , time:0.12762928ms
+                  out_f32x4_col2row: [0.0, 8192.0, 1.0], validate True , time:0.27893376ms
+                  out_f32x4_row2col: [0.0, 8192.0, 1.0], validate True , time:0.12813592ms
+              out_f32x4_col2row(2d): [0.0, 8192.0, 1.0], validate True , time:0.16845822ms
+              out_f32x4_row2col(2d): [0.0, 8192.0, 1.0], validate True , time:0.04240894ms
+       out_f32x4_shared_col2row(2d): [0.0, 8192.0, 1.0], validate True , time:0.05404329ms
+       out_f32x4_shared_row2col(2d): [0.0, 8192.0, 1.0], validate True , time:0.06824255ms
+   out_f32x4_shared_bcf_col2row(2d): [0.0, 8192.0, 1.0], validate True , time:0.05481243ms
+   out_f32x4_shared_bcf_row2col(2d): [0.0, 8192.0, 1.0], validate True , time:0.06005955ms
+ out_mat_transpose_cute_col2row_reg: [0.0, 8192.0, 1.0], validate True , time:0.11488175ms
+ out_mat_transpose_cute_row2col_reg: [0.0, 8192.0, 1.0], validate True , time:0.07866359ms
+    out_mat_transpose_cute_col_smem: [0.0, 8192.0, 1.0], validate True , time:0.11966443ms
+    out_mat_transpose_cute_row_smem: [0.0, 8192.0, 1.0], validate True , time:0.07921481ms
+out_mat_transpose_cute_col_smem_swizzled: [0.0, 8192.0, 1.0], validate True , time:0.10269117ms
+out_mat_transpose_cute_row_smem_swizzled: [0.0, 8192.0, 1.0], validate True , time:0.07479906ms
+out_mat_transpose_cute_row_cvectorized: [0.0, 8192.0, 1.0], validate True , time:0.08218861ms
+out_mat_transpose_cute_row_rvectorized: [0.0, 8192.0, 1.0], validate True , time:0.05100894ms
+out_mat_transpose_cute_row_cvectorized_swizzled: [0.0, 8192.0, 1.0], validate True , time:0.05682635ms
+out_mat_transpose_cute_row_rvectorized_swizzled: [0.0, 8192.0, 1.0], validate True , time:0.05597353ms
+                         out_f32_th: [0.0, 8192.0, 1.0], validate True , time:0.17199111ms
+                out_f32_th_compiled: [0.0, 8192.0, 1.0], validate True , time:0.05846906ms
+----------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------
+                                                       M=4096, N=1024
+                       out_original: [0.0, 1.0, 1024.0], validate False, time:0.01135612ms
+                    out_f32_col2row: [0.0, 1024.0, 1.0], validate True , time:0.06473422ms
+                    out_f32_row2col: [0.0, 1024.0, 1.0], validate True , time:0.03022242ms
+                out_f32_col2row(2d): [0.0, 1024.0, 1.0], validate True , time:0.02885413ms
+                out_f32_row2col(2d): [0.0, 1024.0, 1.0], validate True , time:0.02884769ms
+                  out_f32x4_col2row: [0.0, 1024.0, 1.0], validate True , time:0.06478477ms
+                  out_f32x4_row2col: [0.0, 1024.0, 1.0], validate True , time:0.03187799ms
+              out_f32x4_col2row(2d): [0.0, 1024.0, 1.0], validate True , time:0.03276491ms
+              out_f32x4_row2col(2d): [0.0, 1024.0, 1.0], validate True , time:0.01148319ms
+       out_f32x4_shared_col2row(2d): [0.0, 1024.0, 1.0], validate True , time:0.01368475ms
+       out_f32x4_shared_row2col(2d): [0.0, 1024.0, 1.0], validate True , time:0.01800251ms
+   out_f32x4_shared_bcf_col2row(2d): [0.0, 1024.0, 1.0], validate True , time:0.01427579ms
+   out_f32x4_shared_bcf_row2col(2d): [0.0, 1024.0, 1.0], validate True , time:0.01484346ms
+ out_mat_transpose_cute_col2row_reg: [0.0, 1024.0, 1.0], validate True , time:0.02777314ms
+ out_mat_transpose_cute_row2col_reg: [0.0, 1024.0, 1.0], validate True , time:0.01661682ms
+    out_mat_transpose_cute_col_smem: [0.0, 1024.0, 1.0], validate True , time:0.03186488ms
+    out_mat_transpose_cute_row_smem: [0.0, 1024.0, 1.0], validate True , time:0.01607609ms
+out_mat_transpose_cute_col_smem_swizzled: [0.0, 1024.0, 1.0], validate True , time:0.02742004ms
+out_mat_transpose_cute_row_smem_swizzled: [0.0, 1024.0, 1.0], validate True , time:0.01581359ms
+out_mat_transpose_cute_row_cvectorized: [0.0, 1024.0, 1.0], validate True , time:0.02088809ms
+out_mat_transpose_cute_row_rvectorized: [0.0, 1024.0, 1.0], validate True , time:0.01251507ms
+out_mat_transpose_cute_row_cvectorized_swizzled: [0.0, 1024.0, 1.0], validate True , time:0.01367640ms
+out_mat_transpose_cute_row_rvectorized_swizzled: [0.0, 1024.0, 1.0], validate True , time:0.01482892ms
+                         out_f32_th: [0.0, 1024.0, 1.0], validate True , time:0.04351592ms
+                out_f32_th_compiled: [0.0, 1024.0, 1.0], validate True , time:0.06099153ms
+----------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------
+                                                       M=4096, N=2048
+                       out_original: [0.0, 1.0, 2048.0], validate False, time:0.02611160ms
+                    out_f32_col2row: [0.0, 2048.0, 1.0], validate True , time:0.14095616ms
+                    out_f32_row2col: [0.0, 2048.0, 1.0], validate True , time:0.06800532ms
+                out_f32_col2row(2d): [0.0, 2048.0, 1.0], validate True , time:0.06891775ms
+                out_f32_row2col(2d): [0.0, 2048.0, 1.0], validate True , time:0.06890607ms
+                  out_f32x4_col2row: [0.0, 2048.0, 1.0], validate True , time:0.14629245ms
+                  out_f32x4_row2col: [0.0, 2048.0, 1.0], validate True , time:0.07073379ms
+              out_f32x4_col2row(2d): [0.0, 2048.0, 1.0], validate True , time:0.08693480ms
+              out_f32x4_row2col(2d): [0.0, 2048.0, 1.0], validate True , time:0.02308369ms
+       out_f32x4_shared_col2row(2d): [0.0, 2048.0, 1.0], validate True , time:0.02914500ms
+       out_f32x4_shared_row2col(2d): [0.0, 2048.0, 1.0], validate True , time:0.03913331ms
+   out_f32x4_shared_bcf_col2row(2d): [0.0, 2048.0, 1.0], validate True , time:0.02951288ms
+   out_f32x4_shared_bcf_row2col(2d): [0.0, 2048.0, 1.0], validate True , time:0.03415990ms
+ out_mat_transpose_cute_col2row_reg: [0.0, 2048.0, 1.0], validate True , time:0.05992270ms
+ out_mat_transpose_cute_row2col_reg: [0.0, 2048.0, 1.0], validate True , time:0.04137969ms
+    out_mat_transpose_cute_col_smem: [0.0, 2048.0, 1.0], validate True , time:0.06176162ms
+    out_mat_transpose_cute_row_smem: [0.0, 2048.0, 1.0], validate True , time:0.04155755ms
+out_mat_transpose_cute_col_smem_swizzled: [0.0, 2048.0, 1.0], validate True , time:0.05330944ms
+out_mat_transpose_cute_row_smem_swizzled: [0.0, 2048.0, 1.0], validate True , time:0.03944159ms
+out_mat_transpose_cute_row_cvectorized: [0.0, 2048.0, 1.0], validate True , time:0.04380369ms
+out_mat_transpose_cute_row_rvectorized: [0.0, 2048.0, 1.0], validate True , time:0.02814078ms
+out_mat_transpose_cute_row_cvectorized_swizzled: [0.0, 2048.0, 1.0], validate True , time:0.03094649ms
+out_mat_transpose_cute_row_rvectorized_swizzled: [0.0, 2048.0, 1.0], validate True , time:0.03010845ms
+                         out_f32_th: [0.0, 2048.0, 1.0], validate True , time:0.09364438ms
+                out_f32_th_compiled: [0.0, 2048.0, 1.0], validate True , time:0.05807614ms
+----------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------
+                                                       M=4096, N=4096
+                       out_original: [0.0, 1.0, 4096.0], validate False, time:0.04761362ms
+                    out_f32_col2row: [0.0, 4096.0, 1.0], validate True , time:0.26551914ms
+                    out_f32_row2col: [0.0, 4096.0, 1.0], validate True , time:0.12826180ms
+                out_f32_col2row(2d): [0.0, 4096.0, 1.0], validate True , time:0.12965775ms
+                out_f32_row2col(2d): [0.0, 4096.0, 1.0], validate True , time:0.12970257ms
+                  out_f32_diagnonal: [0.0, 4096.0, 1.0], validate True , time:0.08692741ms
+                  out_f32x4_col2row: [0.0, 4096.0, 1.0], validate True , time:0.27640176ms
+                  out_f32x4_row2col: [0.0, 4096.0, 1.0], validate True , time:0.13386226ms
+              out_f32x4_col2row(2d): [0.0, 4096.0, 1.0], validate True , time:0.16657877ms
+              out_f32x4_row2col(2d): [0.0, 4096.0, 1.0], validate True , time:0.04246473ms
+       out_f32x4_shared_col2row(2d): [0.0, 4096.0, 1.0], validate True , time:0.05401349ms
+       out_f32x4_shared_row2col(2d): [0.0, 4096.0, 1.0], validate True , time:0.07208681ms
+   out_f32x4_shared_bcf_col2row(2d): [0.0, 4096.0, 1.0], validate True , time:0.05456352ms
+   out_f32x4_shared_bcf_row2col(2d): [0.0, 4096.0, 1.0], validate True , time:0.06306529ms
+ out_mat_transpose_cute_col2row_reg: [0.0, 4096.0, 1.0], validate True , time:0.11687827ms
+ out_mat_transpose_cute_row2col_reg: [0.0, 4096.0, 1.0], validate True , time:0.07934999ms
+    out_mat_transpose_cute_col_smem: [0.0, 4096.0, 1.0], validate True , time:0.11962628ms
+    out_mat_transpose_cute_row_smem: [0.0, 4096.0, 1.0], validate True , time:0.07979536ms
+out_mat_transpose_cute_col_smem_swizzled: [0.0, 4096.0, 1.0], validate True , time:0.10279226ms
+out_mat_transpose_cute_row_smem_swizzled: [0.0, 4096.0, 1.0], validate True , time:0.07552862ms
+out_mat_transpose_cute_row_cvectorized: [0.0, 4096.0, 1.0], validate True , time:0.08200026ms
+out_mat_transpose_cute_row_rvectorized: [0.0, 4096.0, 1.0], validate True , time:0.05083799ms
+out_mat_transpose_cute_row_cvectorized_swizzled: [0.0, 4096.0, 1.0], validate True , time:0.05675173ms
+out_mat_transpose_cute_row_rvectorized_swizzled: [0.0, 4096.0, 1.0], validate True , time:0.05572939ms
+                         out_f32_th: [0.0, 4096.0, 1.0], validate True , time:0.17590189ms
+                out_f32_th_compiled: [0.0, 4096.0, 1.0], validate True , time:0.05817580ms
+----------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------
+                                                       M=4096, N=8192
+                       out_original: [0.0, 1.0, 8192.0], validate False, time:0.09065676ms
+                    out_f32_col2row: [0.0, 8192.0, 1.0], validate True , time:0.52875924ms
+                    out_f32_row2col: [0.0, 8192.0, 1.0], validate True , time:0.24883223ms
+                out_f32_col2row(2d): [0.0, 8192.0, 1.0], validate True , time:0.25138545ms
+                out_f32_row2col(2d): [0.0, 8192.0, 1.0], validate True , time:0.25151587ms
+                  out_f32x4_col2row: [0.0, 8192.0, 1.0], validate True , time:0.55523229ms
+                  out_f32x4_row2col: [0.0, 8192.0, 1.0], validate True , time:0.25797868ms
+              out_f32x4_col2row(2d): [0.0, 8192.0, 1.0], validate True , time:0.33464503ms
+              out_f32x4_row2col(2d): [0.0, 8192.0, 1.0], validate True , time:0.08137870ms
+       out_f32x4_shared_col2row(2d): [0.0, 8192.0, 1.0], validate True , time:0.10357594ms
+       out_f32x4_shared_row2col(2d): [0.0, 8192.0, 1.0], validate True , time:0.13923311ms
+   out_f32x4_shared_bcf_col2row(2d): [0.0, 8192.0, 1.0], validate True , time:0.10485888ms
+   out_f32x4_shared_bcf_row2col(2d): [0.0, 8192.0, 1.0], validate True , time:0.12177515ms
+ out_mat_transpose_cute_col2row_reg: [0.0, 8192.0, 1.0], validate True , time:0.22806001ms
+ out_mat_transpose_cute_row2col_reg: [0.0, 8192.0, 1.0], validate True , time:0.15632129ms
+    out_mat_transpose_cute_col_smem: [0.0, 8192.0, 1.0], validate True , time:0.23541665ms
+    out_mat_transpose_cute_row_smem: [0.0, 8192.0, 1.0], validate True , time:0.15710807ms
+out_mat_transpose_cute_col_smem_swizzled: [0.0, 8192.0, 1.0], validate True , time:0.20194674ms
+out_mat_transpose_cute_row_smem_swizzled: [0.0, 8192.0, 1.0], validate True , time:0.14867640ms
+out_mat_transpose_cute_row_cvectorized: [0.0, 8192.0, 1.0], validate True , time:0.15857029ms
+out_mat_transpose_cute_row_rvectorized: [0.0, 8192.0, 1.0], validate True , time:0.09695339ms
+out_mat_transpose_cute_row_cvectorized_swizzled: [0.0, 8192.0, 1.0], validate True , time:0.10866976ms
+out_mat_transpose_cute_row_rvectorized_swizzled: [0.0, 8192.0, 1.0], validate True , time:0.10696220ms
+                         out_f32_th: [0.0, 8192.0, 1.0], validate True , time:0.33883190ms
+                out_f32_th_compiled: [0.0, 8192.0, 1.0], validate True , time:0.07038069ms
+----------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------
+                                                       M=8192, N=1024
+                       out_original: [0.0, 1.0, 1024.0], validate False, time:0.02613044ms
+                    out_f32_col2row: [0.0, 1024.0, 1.0], validate True , time:0.14240122ms
+                    out_f32_row2col: [0.0, 1024.0, 1.0], validate True , time:0.06301308ms
+                out_f32_col2row(2d): [0.0, 1024.0, 1.0], validate True , time:0.06837869ms
+                out_f32_row2col(2d): [0.0, 1024.0, 1.0], validate True , time:0.06840038ms
+                  out_f32x4_col2row: [0.0, 1024.0, 1.0], validate True , time:0.14549279ms
+                  out_f32x4_row2col: [0.0, 1024.0, 1.0], validate True , time:0.06775117ms
+              out_f32x4_col2row(2d): [0.0, 1024.0, 1.0], validate True , time:0.08498430ms
+              out_f32x4_row2col(2d): [0.0, 1024.0, 1.0], validate True , time:0.02311444ms
+       out_f32x4_shared_col2row(2d): [0.0, 1024.0, 1.0], validate True , time:0.02915359ms
+       out_f32x4_shared_row2col(2d): [0.0, 1024.0, 1.0], validate True , time:0.03713298ms
+   out_f32x4_shared_bcf_col2row(2d): [0.0, 1024.0, 1.0], validate True , time:0.02951527ms
+   out_f32x4_shared_bcf_row2col(2d): [0.0, 1024.0, 1.0], validate True , time:0.03300023ms
+ out_mat_transpose_cute_col2row_reg: [0.0, 1024.0, 1.0], validate True , time:0.05988598ms
+ out_mat_transpose_cute_row2col_reg: [0.0, 1024.0, 1.0], validate True , time:0.04108763ms
+    out_mat_transpose_cute_col_smem: [0.0, 1024.0, 1.0], validate True , time:0.06168962ms
+    out_mat_transpose_cute_row_smem: [0.0, 1024.0, 1.0], validate True , time:0.04137659ms
+out_mat_transpose_cute_col_smem_swizzled: [0.0, 1024.0, 1.0], validate True , time:0.05313158ms
+out_mat_transpose_cute_row_smem_swizzled: [0.0, 1024.0, 1.0], validate True , time:0.03937101ms
+out_mat_transpose_cute_row_cvectorized: [0.0, 1024.0, 1.0], validate True , time:0.04361272ms
+out_mat_transpose_cute_row_rvectorized: [0.0, 1024.0, 1.0], validate True , time:0.02782607ms
+out_mat_transpose_cute_row_cvectorized_swizzled: [0.0, 1024.0, 1.0], validate True , time:0.03081965ms
+out_mat_transpose_cute_row_rvectorized_swizzled: [0.0, 1024.0, 1.0], validate True , time:0.02822685ms
+                         out_f32_th: [0.0, 1024.0, 1.0], validate True , time:0.08901119ms
+                out_f32_th_compiled: [0.0, 1024.0, 1.0], validate True , time:0.05782843ms
+----------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------
+                                                       M=8192, N=2048
+                       out_original: [0.0, 1.0, 2048.0], validate False, time:0.04759407ms
+                    out_f32_col2row: [0.0, 2048.0, 1.0], validate True , time:0.27500105ms
+                    out_f32_row2col: [0.0, 2048.0, 1.0], validate True , time:0.12144923ms
+                out_f32_col2row(2d): [0.0, 2048.0, 1.0], validate True , time:0.13192320ms
+                out_f32_row2col(2d): [0.0, 2048.0, 1.0], validate True , time:0.13188601ms
+                  out_f32x4_col2row: [0.0, 2048.0, 1.0], validate True , time:0.29046535ms
+                  out_f32x4_row2col: [0.0, 2048.0, 1.0], validate True , time:0.13048077ms
+              out_f32x4_col2row(2d): [0.0, 2048.0, 1.0], validate True , time:0.17475128ms
+              out_f32x4_row2col(2d): [0.0, 2048.0, 1.0], validate True , time:0.04228449ms
+       out_f32x4_shared_col2row(2d): [0.0, 2048.0, 1.0], validate True , time:0.05392790ms
+       out_f32x4_shared_row2col(2d): [0.0, 2048.0, 1.0], validate True , time:0.06848621ms
+   out_f32x4_shared_bcf_col2row(2d): [0.0, 2048.0, 1.0], validate True , time:0.05463552ms
+   out_f32x4_shared_bcf_row2col(2d): [0.0, 2048.0, 1.0], validate True , time:0.06046867ms
+ out_mat_transpose_cute_col2row_reg: [0.0, 2048.0, 1.0], validate True , time:0.11590195ms
+ out_mat_transpose_cute_row2col_reg: [0.0, 2048.0, 1.0], validate True , time:0.07939339ms
+    out_mat_transpose_cute_col_smem: [0.0, 2048.0, 1.0], validate True , time:0.11953950ms
+    out_mat_transpose_cute_row_smem: [0.0, 2048.0, 1.0], validate True , time:0.07990146ms
+out_mat_transpose_cute_col_smem_swizzled: [0.0, 2048.0, 1.0], validate True , time:0.10252953ms
+out_mat_transpose_cute_row_smem_swizzled: [0.0, 2048.0, 1.0], validate True , time:0.07594895ms
+out_mat_transpose_cute_row_cvectorized: [0.0, 2048.0, 1.0], validate True , time:0.08208942ms
+out_mat_transpose_cute_row_rvectorized: [0.0, 2048.0, 1.0], validate True , time:0.05093598ms
+out_mat_transpose_cute_row_cvectorized_swizzled: [0.0, 2048.0, 1.0], validate True , time:0.05676866ms
+out_mat_transpose_cute_row_rvectorized_swizzled: [0.0, 2048.0, 1.0], validate True , time:0.05595016ms
+                         out_f32_th: [0.0, 2048.0, 1.0], validate True , time:0.17065334ms
+                out_f32_th_compiled: [0.0, 2048.0, 1.0], validate True , time:0.05812144ms
+----------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------
+                                                       M=8192, N=4096
+                       out_original: [0.0, 1.0, 4096.0], validate False, time:0.09060454ms
+                    out_f32_col2row: [0.0, 4096.0, 1.0], validate True , time:0.53396153ms
+                    out_f32_row2col: [0.0, 4096.0, 1.0], validate True , time:0.23736954ms
+                out_f32_col2row(2d): [0.0, 4096.0, 1.0], validate True , time:0.25855660ms
+                out_f32_row2col(2d): [0.0, 4096.0, 1.0], validate True , time:0.25850701ms
+                  out_f32x4_col2row: [0.0, 4096.0, 1.0], validate True , time:0.56433153ms
+                  out_f32x4_row2col: [0.0, 4096.0, 1.0], validate True , time:0.25520277ms
+              out_f32x4_col2row(2d): [0.0, 4096.0, 1.0], validate True , time:0.34376645ms
+              out_f32x4_row2col(2d): [0.0, 4096.0, 1.0], validate True , time:0.08140516ms
+       out_f32x4_shared_col2row(2d): [0.0, 4096.0, 1.0], validate True , time:0.10327840ms
+       out_f32x4_shared_row2col(2d): [0.0, 4096.0, 1.0], validate True , time:0.13143134ms
+   out_f32x4_shared_bcf_col2row(2d): [0.0, 4096.0, 1.0], validate True , time:0.10436797ms
+   out_f32x4_shared_bcf_row2col(2d): [0.0, 4096.0, 1.0], validate True , time:0.11549497ms
+ out_mat_transpose_cute_col2row_reg: [0.0, 4096.0, 1.0], validate True , time:0.22957921ms
+ out_mat_transpose_cute_row2col_reg: [0.0, 4096.0, 1.0], validate True , time:0.15648627ms
+    out_mat_transpose_cute_col_smem: [0.0, 4096.0, 1.0], validate True , time:0.23523784ms
+    out_mat_transpose_cute_row_smem: [0.0, 4096.0, 1.0], validate True , time:0.15738535ms
+out_mat_transpose_cute_col_smem_swizzled: [0.0, 4096.0, 1.0], validate True , time:0.20139265ms
+out_mat_transpose_cute_row_smem_swizzled: [0.0, 4096.0, 1.0], validate True , time:0.14952707ms
+out_mat_transpose_cute_row_cvectorized: [0.0, 4096.0, 1.0], validate True , time:0.15815616ms
+out_mat_transpose_cute_row_rvectorized: [0.0, 4096.0, 1.0], validate True , time:0.09657621ms
+out_mat_transpose_cute_row_cvectorized_swizzled: [0.0, 4096.0, 1.0], validate True , time:0.10863233ms
+out_mat_transpose_cute_row_rvectorized_swizzled: [0.0, 4096.0, 1.0], validate True , time:0.10682678ms
+                         out_f32_th: [0.0, 4096.0, 1.0], validate True , time:0.33217621ms
+                out_f32_th_compiled: [0.0, 4096.0, 1.0], validate True , time:0.07057214ms
+----------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------
+                                                       M=8192, N=8192
+                       out_original: [0.0, 1.0, 8192.0], validate False, time:0.17657781ms
+                    out_f32_col2row: [0.0, 8192.0, 1.0], validate True , time:1.05990601ms
+                    out_f32_row2col: [0.0, 8192.0, 1.0], validate True , time:0.46211433ms
+                out_f32_col2row(2d): [0.0, 8192.0, 1.0], validate True , time:0.50515103ms
+                out_f32_row2col(2d): [0.0, 8192.0, 1.0], validate True , time:0.50519037ms
+                  out_f32_diagnonal: [0.0, 8192.0, 1.0], validate True , time:0.34358025ms
+                  out_f32x4_col2row: [0.0, 8192.0, 1.0], validate True , time:1.10640693ms
+                  out_f32x4_row2col: [0.0, 8192.0, 1.0], validate True , time:0.49680948ms
+              out_f32x4_col2row(2d): [0.0, 8192.0, 1.0], validate True , time:0.67155337ms
+              out_f32x4_row2col(2d): [0.0, 8192.0, 1.0], validate True , time:0.15931034ms
+       out_f32x4_shared_col2row(2d): [0.0, 8192.0, 1.0], validate True , time:0.20235109ms
+       out_f32x4_shared_row2col(2d): [0.0, 8192.0, 1.0], validate True , time:0.25867033ms
+   out_f32x4_shared_bcf_col2row(2d): [0.0, 8192.0, 1.0], validate True , time:0.20493627ms
+   out_f32x4_shared_bcf_row2col(2d): [0.0, 8192.0, 1.0], validate True , time:0.22880530ms
+ out_mat_transpose_cute_col2row_reg: [0.0, 8192.0, 1.0], validate True , time:0.45240569ms
+ out_mat_transpose_cute_row2col_reg: [0.0, 8192.0, 1.0], validate True , time:0.31271243ms
+    out_mat_transpose_cute_col_smem: [0.0, 8192.0, 1.0], validate True , time:0.46673679ms
+    out_mat_transpose_cute_row_smem: [0.0, 8192.0, 1.0], validate True , time:0.31364536ms
+out_mat_transpose_cute_col_smem_swizzled: [0.0, 8192.0, 1.0], validate True , time:0.39961338ms
+out_mat_transpose_cute_row_smem_swizzled: [0.0, 8192.0, 1.0], validate True , time:0.29810309ms
+out_mat_transpose_cute_row_cvectorized: [0.0, 8192.0, 1.0], validate True , time:0.31140137ms
+out_mat_transpose_cute_row_rvectorized: [0.0, 8192.0, 1.0], validate True , time:0.18832517ms
+out_mat_transpose_cute_row_cvectorized_swizzled: [0.0, 8192.0, 1.0], validate True , time:0.21277142ms
+out_mat_transpose_cute_row_rvectorized_swizzled: [0.0, 8192.0, 1.0], validate True , time:0.20939684ms
+                         out_f32_th: [0.0, 8192.0, 1.0], validate True , time:0.64468265ms
+                out_f32_th_compiled: [0.0, 8192.0, 1.0], validate True , time:0.13783288ms
+----------------------------------------------------------------------------------------------------------------------------------
+
 ```

--- a/kernels/mat-transpose/mat_transpose.cu
+++ b/kernels/mat-transpose/mat_transpose.cu
@@ -337,6 +337,7 @@ TORCH_BINDING_MAT_TRANSPOSE2D(f32x4_shared_bcf_row2col, torch::kFloat32, float, 
 // TODO: may support double buffer pipeline mat transpose ?
 // TODO: may support fp16 mat transpose ?
 
+extern void mat_transpose_cute(torch::Tensor x, torch::Tensor y);
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   // 1d index
@@ -357,4 +358,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   //shared memory optimize with bcf
   TORCH_BINDING_COMMON_EXTENSION(mat_transpose_f32x4_shared_bcf_col2row2d)
   TORCH_BINDING_COMMON_EXTENSION(mat_transpose_f32x4_shared_bcf_row2col2d)
+  // cute
+  TORCH_BINDING_COMMON_EXTENSION(mat_transpose_cute)
 }

--- a/kernels/mat-transpose/mat_transpose.cu
+++ b/kernels/mat-transpose/mat_transpose.cu
@@ -338,9 +338,17 @@ TORCH_BINDING_MAT_TRANSPOSE2D(f32x4_shared_bcf_row2col, torch::kFloat32, float, 
 // TODO: may support fp16 mat transpose ?
 
 // CuTe implentations
-extern void mat_transpose_cute_row2col_naive(torch::Tensor, torch::Tensor);
-extern void mat_transpose_cute_row2col_vectorized(torch::Tensor, torch::Tensor);
-extern void mat_transpose_cute_row2col_swizzled(torch::Tensor, torch::Tensor);
+extern void mat_transpose_cute_col2row_reg(torch::Tensor, torch::Tensor);
+extern void mat_transpose_cute_row2col_reg(torch::Tensor, torch::Tensor);
+extern void mat_transpose_cute_col_smem(torch::Tensor, torch::Tensor);
+extern void mat_transpose_cute_row_smem(torch::Tensor, torch::Tensor);
+extern void mat_transpose_cute_col_smem_swizzled(torch::Tensor, torch::Tensor);
+extern void mat_transpose_cute_row_smem_swizzled(torch::Tensor, torch::Tensor);
+extern void mat_transpose_cute_row_cvectorized(torch::Tensor, torch::Tensor);
+extern void mat_transpose_cute_row_rvectorized(torch::Tensor, torch::Tensor);
+extern void mat_transpose_cute_row_cvectorized_swizzled(torch::Tensor, torch::Tensor);
+extern void mat_transpose_cute_row_rvectorized_swizzled(torch::Tensor, torch::Tensor);
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   // 1d index
   TORCH_BINDING_COMMON_EXTENSION(mat_transpose_f32_col2row)
@@ -360,8 +368,15 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   //shared memory optimize with bcf
   TORCH_BINDING_COMMON_EXTENSION(mat_transpose_f32x4_shared_bcf_col2row2d)
   TORCH_BINDING_COMMON_EXTENSION(mat_transpose_f32x4_shared_bcf_row2col2d)
-  // cute
-  TORCH_BINDING_COMMON_EXTENSION(mat_transpose_cute_row2col_naive)
-  TORCH_BINDING_COMMON_EXTENSION(mat_transpose_cute_row2col_swizzled)
-  TORCH_BINDING_COMMON_EXTENSION(mat_transpose_cute_row2col_vectorized)
+  // CuTe implentations
+  TORCH_BINDING_COMMON_EXTENSION(mat_transpose_cute_col2row_reg)
+  TORCH_BINDING_COMMON_EXTENSION(mat_transpose_cute_row2col_reg)
+  TORCH_BINDING_COMMON_EXTENSION(mat_transpose_cute_row_smem)
+  TORCH_BINDING_COMMON_EXTENSION(mat_transpose_cute_col_smem)
+  TORCH_BINDING_COMMON_EXTENSION(mat_transpose_cute_col_smem_swizzled)
+  TORCH_BINDING_COMMON_EXTENSION(mat_transpose_cute_row_smem_swizzled)
+  TORCH_BINDING_COMMON_EXTENSION(mat_transpose_cute_row_cvectorized)
+  TORCH_BINDING_COMMON_EXTENSION(mat_transpose_cute_row_rvectorized)
+  TORCH_BINDING_COMMON_EXTENSION(mat_transpose_cute_row_cvectorized_swizzled)
+  TORCH_BINDING_COMMON_EXTENSION(mat_transpose_cute_row_rvectorized_swizzled)
 }

--- a/kernels/mat-transpose/mat_transpose.cu
+++ b/kernels/mat-transpose/mat_transpose.cu
@@ -340,7 +340,7 @@ TORCH_BINDING_MAT_TRANSPOSE2D(f32x4_shared_bcf_row2col, torch::kFloat32, float, 
 // CuTe implentations
 extern void mat_transpose_cute_row2col_naive(torch::Tensor, torch::Tensor);
 extern void mat_transpose_cute_row2col_vectorized(torch::Tensor, torch::Tensor);
-
+extern void mat_transpose_cute_row2col_swizzled(torch::Tensor, torch::Tensor);
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   // 1d index
   TORCH_BINDING_COMMON_EXTENSION(mat_transpose_f32_col2row)
@@ -362,5 +362,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   TORCH_BINDING_COMMON_EXTENSION(mat_transpose_f32x4_shared_bcf_row2col2d)
   // cute
   TORCH_BINDING_COMMON_EXTENSION(mat_transpose_cute_row2col_naive)
+  TORCH_BINDING_COMMON_EXTENSION(mat_transpose_cute_row2col_swizzled)
   TORCH_BINDING_COMMON_EXTENSION(mat_transpose_cute_row2col_vectorized)
 }

--- a/kernels/mat-transpose/mat_transpose.cu
+++ b/kernels/mat-transpose/mat_transpose.cu
@@ -337,7 +337,9 @@ TORCH_BINDING_MAT_TRANSPOSE2D(f32x4_shared_bcf_row2col, torch::kFloat32, float, 
 // TODO: may support double buffer pipeline mat transpose ?
 // TODO: may support fp16 mat transpose ?
 
-extern void mat_transpose_cute(torch::Tensor x, torch::Tensor y);
+// CuTe implentations
+extern void mat_transpose_cute_row2col_naive(torch::Tensor, torch::Tensor);
+extern void mat_transpose_cute_row2col_vectorized(torch::Tensor, torch::Tensor);
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   // 1d index
@@ -359,5 +361,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   TORCH_BINDING_COMMON_EXTENSION(mat_transpose_f32x4_shared_bcf_col2row2d)
   TORCH_BINDING_COMMON_EXTENSION(mat_transpose_f32x4_shared_bcf_row2col2d)
   // cute
-  TORCH_BINDING_COMMON_EXTENSION(mat_transpose_cute)
+  TORCH_BINDING_COMMON_EXTENSION(mat_transpose_cute_row2col_naive)
+  TORCH_BINDING_COMMON_EXTENSION(mat_transpose_cute_row2col_vectorized)
 }

--- a/kernels/mat-transpose/mat_transpose.py
+++ b/kernels/mat-transpose/mat_transpose.py
@@ -72,10 +72,10 @@ def run_benchmark(
 def transpose_copy_compiled(input: torch.Tensor, out: torch.Tensor):
     return torch.transpose_copy(input, dim0=0, dim1=1, out=out)
 
-Ms = [8192] # [1024, 2048, 4096]
-Ns = [8192] # [1024, 2048, 4096]
+Ms = [1024, 2048, 4096, 8192]
+Ns = [1024, 2048, 4096, 8192]
 MNs = [(M, N) for M in Ms for N in Ns]
-copy_x = lambda x: x
+copy_x = lambda x: x.clone()
 # show the three elements x[0][0], x[0][1], x[1][0]
 for M, N in MNs:
     print("-" * 130)
@@ -97,9 +97,16 @@ for M, N in MNs:
     run_benchmark(lib.mat_transpose_f32x4_shared_row2col2d, x, "f32x4_shared_row2col(2d)", y)
     run_benchmark(lib.mat_transpose_f32x4_shared_bcf_col2row2d, x, "f32x4_shared_bcf_col2row(2d)", y)
     run_benchmark(lib.mat_transpose_f32x4_shared_bcf_row2col2d, x, "f32x4_shared_bcf_row2col(2d)", y)
-    run_benchmark(lib.mat_transpose_cute_row2col_naive, x, "mat_transpose_cute_row2col_naive", y)
-    run_benchmark(lib.mat_transpose_cute_row2col_swizzled, x, "mat_transpomat_transpose_cute_row2col_swizzledse_cute_row2col", y)
-    run_benchmark(lib.mat_transpose_cute_row2col_vectorized, x, "mat_transpose_cute_row2col_vectorized", y)
+    run_benchmark(lib.mat_transpose_cute_col2row_reg, x, "mat_transpose_cute_col2row_reg", y)
+    run_benchmark(lib.mat_transpose_cute_row2col_reg, x, "mat_transpose_cute_row2col_reg", y)
+    run_benchmark(lib.mat_transpose_cute_col_smem, x, "mat_transpose_cute_col_smem", y)
+    run_benchmark(lib.mat_transpose_cute_row_smem, x, "mat_transpose_cute_row_smem", y)
+    run_benchmark(lib.mat_transpose_cute_col_smem_swizzled, x, "mat_transpose_cute_col_smem_swizzled", y)
+    run_benchmark(lib.mat_transpose_cute_row_smem_swizzled, x, "mat_transpose_cute_row_smem_swizzled", y)
+    run_benchmark(lib.mat_transpose_cute_row_cvectorized, x, "mat_transpose_cute_row_cvectorized", y)
+    run_benchmark(lib.mat_transpose_cute_row_rvectorized, x, "mat_transpose_cute_row_rvectorized", y)
+    run_benchmark(lib.mat_transpose_cute_row_cvectorized_swizzled, x, "mat_transpose_cute_row_cvectorized_swizzled", y)
+    run_benchmark(lib.mat_transpose_cute_row_rvectorized_swizzled, x, "mat_transpose_cute_row_rvectorized_swizzled", y)
     run_benchmark(partial(torch.transpose_copy, dim0=0, dim1=1, out=y), x, "f32_th")
     run_benchmark(partial(transpose_copy_compiled, out=y), x, "f32_th_compiled")
     print("-" * 130)

--- a/kernels/mat-transpose/mat_transpose.py
+++ b/kernels/mat-transpose/mat_transpose.py
@@ -72,8 +72,8 @@ def run_benchmark(
 def transpose_copy_compiled(input: torch.Tensor, out: torch.Tensor):
     return torch.transpose_copy(input, dim0=0, dim1=1, out=out)
 
-Ms = [1024, 2048, 4096]
-Ns = [1024, 2048, 4096]
+Ms = [8192] # [1024, 2048, 4096]
+Ns = [8192] # [1024, 2048, 4096]
 MNs = [(M, N) for M in Ms for N in Ns]
 copy_x = lambda x: x
 # show the three elements x[0][0], x[0][1], x[1][0]
@@ -98,6 +98,7 @@ for M, N in MNs:
     run_benchmark(lib.mat_transpose_f32x4_shared_bcf_col2row2d, x, "f32x4_shared_bcf_col2row(2d)", y)
     run_benchmark(lib.mat_transpose_f32x4_shared_bcf_row2col2d, x, "f32x4_shared_bcf_row2col(2d)", y)
     run_benchmark(lib.mat_transpose_cute_row2col_naive, x, "mat_transpose_cute_row2col_naive", y)
+    run_benchmark(lib.mat_transpose_cute_row2col_swizzled, x, "mat_transpomat_transpose_cute_row2col_swizzledse_cute_row2col", y)
     run_benchmark(lib.mat_transpose_cute_row2col_vectorized, x, "mat_transpose_cute_row2col_vectorized", y)
     run_benchmark(partial(torch.transpose_copy, dim0=0, dim1=1, out=y), x, "f32_th")
     run_benchmark(partial(transpose_copy_compiled, out=y), x, "f32_th_compiled")

--- a/kernels/mat-transpose/mat_transpose_cute.cu
+++ b/kernels/mat-transpose/mat_transpose_cute.cu
@@ -1,27 +1,26 @@
+#include <cuda_runtime.h>
+#include <stdio.h>
 #include <torch/types.h>
 
 #include <cute/layout.hpp>
 #include <cute/tensor.hpp>
 
-#include <stdio.h>
-#include <cuda_runtime.h>
-
-#define CUDA_CHECK(call)                                                 \
-    do {                                                                 \
-        cudaError_t err = call;                                          \
-        if (err != cudaSuccess) {                                        \
-            fprintf(stderr, "CUDA error at %s:%d: %s\n", __FILE__,       \
-                    __LINE__, cudaGetErrorString(err));                  \
-            /* Optionally, you could also call cudaDeviceReset here */   \
-            exit(EXIT_FAILURE);                                          \
-        }                                                                \
-    } while (0)
+#define CUDA_CHECK(call)                                               \
+  do {                                                                 \
+    cudaError_t err = call;                                            \
+    if (err != cudaSuccess) {                                          \
+      fprintf(stderr, "CUDA error at %s:%d: %s\n", __FILE__, __LINE__, \
+              cudaGetErrorString(err));                                \
+      /* Optionally, you could also call cudaDeviceReset here */       \
+      exit(EXIT_FAILURE);                                              \
+    }                                                                  \
+  } while (0)
 
 using namespace cute;
 
 template <typename T, typename ThreadLayout, int BLK_M, int BLK_N>
 __global__ void mat_transpose_row2col(const T *pA, T *pB, int M, int N,
-                                      ThreadLayout tA) {
+                                      ThreadLayout tAB) {
   int tx = threadIdx.x;
   int bx = blockIdx.x, by = blockIdx.y;
 
@@ -36,6 +35,12 @@ __global__ void mat_transpose_row2col(const T *pA, T *pB, int M, int N,
                        make_coord(bx, by));  // (BM, BN)
   auto gB = local_tile(mB, make_shape(Int<BLK_N>{}, Int<BLK_M>{}),
                        make_coord(by, bx));  // (BN, BM)
+  auto cA = local_tile(make_identity_tensor(mA.shape()),
+                       make_shape(Int<BLK_M>{}, Int<BLK_N>{}),
+                       make_coord(bx, by));  // (BM, BN)
+  auto cB = local_tile(make_identity_tensor(mB.shape()),
+                       make_shape(Int<BLK_N>{}, Int<BLK_M>{}),
+                       make_coord(by, bx));  // (BN, BM)
 
   __shared__ T smem[BLK_M * BLK_N];
   auto sA = make_tensor(
@@ -45,14 +50,32 @@ __global__ void mat_transpose_row2col(const T *pA, T *pB, int M, int N,
       make_smem_ptr(smem),
       make_layout(make_shape(BLK_N, BLK_M), GenColMajor{}));  // (BN, BM)
 
-  Tensor tAgA = local_partition(gA, tA, tx);
-  Tensor tAgB = local_partition(gB, tA, tx);
-  Tensor tAsA = local_partition(sA, tA, tx);
-  Tensor tAsB = local_partition(sB, tA, tx);
+  Tensor tAgA = local_partition(gA, tAB, tx);
+  Tensor tBgB = local_partition(gB, tAB, tx);
+  Tensor tAsA = local_partition(sA, tAB, tx);
+  Tensor tBsB = local_partition(sB, tAB, tx);
+  Tensor tAcA = local_partition(cA, tAB, tx);
+  Tensor tBcB = local_partition(cB, tAB, tx);
 
-  copy(tAgA, tAsA);
+  Tensor tApA = make_tensor<bool>(tAcA.shape(), tAcA.stride());
+  Tensor tBpB = make_tensor<bool>(tBcB.shape(), tBcB.stride());
+  CUTE_UNROLL
+  for (int i = 0; i < size<0>(tApA); i++) {
+    CUTE_UNROLL
+    for (int j = 0; j < size<1>(tApA); j++) {
+      tApA(i, j) = get<0>(tAcA(i, j)) < M && get<1>(tAcA(i, j)) < N;
+    }
+  }
+  CUTE_UNROLL
+  for (int i = 0; i < size<0>(tBpB); i++) {
+    CUTE_UNROLL
+    for (int j = 0; j < size<1>(tBpB); j++) {
+      tBpB(i, j) = get<0>(tBcB(i, j)) < N && get<1>(tBcB(i, j)) < M;
+    }
+  }
+  copy_if(tApA, tAgA, tAsA);
   __syncthreads();
-  copy(tAsB, tAgB);
+  copy_if(tBpB, tBsB, tBgB);
 }
 
 void mat_transpose_cute(torch::Tensor x, torch::Tensor y) {
@@ -60,10 +83,10 @@ void mat_transpose_cute(torch::Tensor x, torch::Tensor y) {
   const int BN = 16;
   const int M = x.size(0);
   const int N = x.size(1);
-  auto tA = make_layout(make_shape(Int<BM>{}, Int<BN>{}));
-  dim3 block(size(tA));
-  dim3 grid(M / BM, N / BN);
-  mat_transpose_row2col<float, decltype(tA), BM, BN>
-      <<<grid, block>>>(x.data_ptr<float>(), y.data_ptr<float>(), M, N, tA);
+  auto tAB = make_layout(make_shape(Int<BM>{}, Int<BN>{}));
+  dim3 block(size(tAB));
+  dim3 grid((M + BM - 1) / BM, (N + BN - 1) / BN);
+  mat_transpose_row2col<float, decltype(tAB), BM, BN>
+      <<<grid, block>>>(x.data_ptr<float>(), y.data_ptr<float>(), M, N, tAB);
   CUDA_CHECK(cudaGetLastError());
 }

--- a/kernels/mat-transpose/mat_transpose_cute.cu
+++ b/kernels/mat-transpose/mat_transpose_cute.cu
@@ -1,0 +1,69 @@
+#include <torch/types.h>
+
+#include <cute/layout.hpp>
+#include <cute/tensor.hpp>
+
+#include <stdio.h>
+#include <cuda_runtime.h>
+
+#define CUDA_CHECK(call)                                                 \
+    do {                                                                 \
+        cudaError_t err = call;                                          \
+        if (err != cudaSuccess) {                                        \
+            fprintf(stderr, "CUDA error at %s:%d: %s\n", __FILE__,       \
+                    __LINE__, cudaGetErrorString(err));                  \
+            /* Optionally, you could also call cudaDeviceReset here */   \
+            exit(EXIT_FAILURE);                                          \
+        }                                                                \
+    } while (0)
+
+using namespace cute;
+
+template <typename T, typename ThreadLayout, int BLK_M, int BLK_N>
+__global__ void mat_transpose_row2col(const T *pA, T *pB, int M, int N,
+                                      ThreadLayout tA) {
+  int tx = threadIdx.x;
+  int bx = blockIdx.x, by = blockIdx.y;
+
+  auto mA =
+      make_tensor(make_gmem_ptr(pA),
+                  make_layout(make_shape(M, N), GenRowMajor{}));  // (M, N)
+  auto mB =
+      make_tensor(make_gmem_ptr(pB),
+                  make_layout(make_shape(N, M), GenRowMajor{}));  // (N, N)
+
+  auto gA = local_tile(mA, make_shape(Int<BLK_M>{}, Int<BLK_N>{}),
+                       make_coord(bx, by));  // (BM, BN)
+  auto gB = local_tile(mB, make_shape(Int<BLK_N>{}, Int<BLK_M>{}),
+                       make_coord(by, bx));  // (BN, BM)
+
+  __shared__ T smem[BLK_M * BLK_N];
+  auto sA = make_tensor(
+      make_smem_ptr(smem),
+      make_layout(make_shape(BLK_M, BLK_N), GenRowMajor{}));  // (BM, BN)
+  auto sB = make_tensor(
+      make_smem_ptr(smem),
+      make_layout(make_shape(BLK_N, BLK_M), GenColMajor{}));  // (BN, BM)
+
+  Tensor tAgA = local_partition(gA, tA, tx);
+  Tensor tAgB = local_partition(gB, tA, tx);
+  Tensor tAsA = local_partition(sA, tA, tx);
+  Tensor tAsB = local_partition(sB, tA, tx);
+
+  copy(tAgA, tAsA);
+  __syncthreads();
+  copy(tAsB, tAgB);
+}
+
+void mat_transpose_cute(torch::Tensor x, torch::Tensor y) {
+  const int BM = 16;
+  const int BN = 16;
+  const int M = x.size(0);
+  const int N = x.size(1);
+  auto tA = make_layout(make_shape(Int<BM>{}, Int<BN>{}));
+  dim3 block(size(tA));
+  dim3 grid(M / BM, N / BN);
+  mat_transpose_row2col<float, decltype(tA), BM, BN>
+      <<<grid, block>>>(x.data_ptr<float>(), y.data_ptr<float>(), M, N, tA);
+  CUDA_CHECK(cudaGetLastError());
+}

--- a/kernels/mat-transpose/mat_transpose_cute.cu
+++ b/kernels/mat-transpose/mat_transpose_cute.cu
@@ -18,9 +18,10 @@
 
 using namespace cute;
 
-template <typename T, typename ThreadLayout, int BLK_M, int BLK_N>
-__global__ void mat_transpose_row2col(const T *pA, T *pB, int M, int N,
-                                      ThreadLayout tAB) {
+template <typename T, int BLK_M, int BLK_N, typename ThreadLayout>
+__global__ void mat_transpose_cute_row2col_naive_kernel(const T *pA, T *pB,
+                                                        int M, int N,
+                                                        ThreadLayout tAB) {
   int tx = threadIdx.x;
   int bx = blockIdx.x, by = blockIdx.y;
 
@@ -29,7 +30,7 @@ __global__ void mat_transpose_row2col(const T *pA, T *pB, int M, int N,
                   make_layout(make_shape(M, N), GenRowMajor{}));  // (M, N)
   auto mB =
       make_tensor(make_gmem_ptr(pB),
-                  make_layout(make_shape(N, M), GenRowMajor{}));  // (N, N)
+                  make_layout(make_shape(N, M), GenRowMajor{}));  // (N, M)
 
   auto gA = local_tile(mA, make_shape(Int<BLK_M>{}, Int<BLK_N>{}),
                        make_coord(bx, by));  // (BM, BN)
@@ -78,15 +79,93 @@ __global__ void mat_transpose_row2col(const T *pA, T *pB, int M, int N,
   copy_if(tBpB, tBsB, tBgB);
 }
 
-void mat_transpose_cute(torch::Tensor x, torch::Tensor y) {
+void mat_transpose_cute_row2col_naive(torch::Tensor x, torch::Tensor y) {
   const int BM = 16;
   const int BN = 16;
   const int M = x.size(0);
   const int N = x.size(1);
-  auto tAB = make_layout(make_shape(Int<BM>{}, Int<BN>{}));
+  auto tAB = make_layout(make_shape(Int<BM>{}, Int<BN>{}), GenRowMajor{});
   dim3 block(size(tAB));
   dim3 grid((M + BM - 1) / BM, (N + BN - 1) / BN);
-  mat_transpose_row2col<float, decltype(tAB), BM, BN>
+  mat_transpose_cute_row2col_naive_kernel<float, BM, BN, decltype(tAB)>
       <<<grid, block>>>(x.data_ptr<float>(), y.data_ptr<float>(), M, N, tAB);
+  CUDA_CHECK(cudaGetLastError());
+}
+
+__host__ __device__ inline bool is_aligned_128(const void *ptr) {
+  return (reinterpret_cast<uintptr_t>(ptr) & 0xF) == 0;
+}
+
+template <typename T, int BLK_M, int BLK_N, typename TiledCopyA,
+          typename TiledCopyB>
+__global__ void mat_transpose_cute_row2col_vectorized_kernel(
+    const T *pA, T *pB, int M, int N, TiledCopyA copy_a, TiledCopyB copy_b) {
+  int tx = threadIdx.x;
+  int bx = blockIdx.x, by = blockIdx.y;
+
+  auto mA =
+      make_tensor(make_gmem_ptr(pA),
+                  make_layout(make_shape(M, N), GenRowMajor{}));  // (M, N)
+  auto mB =
+      make_tensor(make_gmem_ptr(pB),
+                  make_layout(make_shape(N, M), GenRowMajor{}));  // (N, N)
+
+  auto gA = local_tile(mA, make_shape(Int<BLK_M>{}, Int<BLK_N>{}),
+                       make_coord(bx, by));  // (BM, BN)
+  auto gB = local_tile(mB, make_shape(Int<BLK_N>{}, Int<BLK_M>{}),
+                       make_coord(by, bx));  // (BN, BM)
+
+  __shared__ T smem[BLK_M * BLK_N];
+  auto sA = make_tensor(
+      make_smem_ptr(smem),
+      make_layout(make_shape(BLK_M, BLK_N), GenRowMajor{}));  // (BM, BN)
+  auto sB = make_tensor(
+      make_smem_ptr(smem),
+      make_layout(make_shape(BLK_N, BLK_M), GenColMajor{}));  // (BN, BM)
+
+  auto thr_copy_a = copy_a.get_slice(tx);
+  Tensor tAgA = thr_copy_a.partition_S(gA);
+  Tensor tAsA = thr_copy_a.partition_D(sA);
+
+  auto thr_copy_b = copy_b.get_slice(tx);
+  Tensor tBsB = thr_copy_b.partition_S(sB);
+  Tensor tBgB = thr_copy_b.partition_D(gB);
+
+  copy(copy_a, tAgA, tAsA);
+  __syncthreads();
+  copy(copy_b, tBsB, tBgB);
+}
+
+void mat_transpose_cute_row2col_vectorized(torch::Tensor x, torch::Tensor y) {
+  const int BM = 16;
+  const int BN = 64;
+  auto ptr_A = x.data_ptr<float>();
+  auto ptr_B = y.data_ptr<float>();
+  const int M = x.size(0);
+  const int N = x.size(1);
+
+  // sanity checks
+  assert(M % 4 == 0);
+  assert(N % 4 == 0);
+  static_assert(BM % 4 == 0);
+  static_assert(BN % 4 == 0);
+  assert(is_aligned_128(ptr_A));
+  assert(is_aligned_128(ptr_B));
+
+  auto tile_copy_a = make_tiled_copy(
+      Copy_Atom<AutoVectorizingCopy, float>{},
+      make_layout(make_shape(Int<BM>{}, Int<BN / 4>{}), GenRowMajor{}),
+      make_layout(make_shape(Int<1>{}, Int<4>{}), GenRowMajor{}));
+  auto tile_copy_b = make_tiled_copy(
+      Copy_Atom<AutoVectorizingCopy, float>{},
+      make_layout(make_shape(Int<BN / 4>{}, Int<BM>{}), GenRowMajor{}),
+      make_layout(make_shape(Int<4>{}, Int<1>{}), GenRowMajor{}));
+
+  static_assert(size(tile_copy_a) == size(tile_copy_b));
+  dim3 block(size(tile_copy_a));
+  dim3 grid((M + BM - 1) / BM, (N + BN - 1) / BN);
+  mat_transpose_cute_row2col_vectorized_kernel<
+      float, BM, BN, decltype(tile_copy_a), decltype(tile_copy_b)>
+      <<<grid, block>>>(ptr_A, ptr_B, M, N, tile_copy_a, tile_copy_b);
   CUDA_CHECK(cudaGetLastError());
 }

--- a/kernels/mat-transpose/mat_transpose_cute.cu
+++ b/kernels/mat-transpose/mat_transpose_cute.cu
@@ -1,9 +1,12 @@
 #include <cuda_runtime.h>
 #include <stdio.h>
-#include <torch/types.h>
+#include <torch/extension.h>
 
 #include <cute/layout.hpp>
 #include <cute/tensor.hpp>
+using namespace cute;
+
+#define UNIT_BLK_SIZE 16
 
 #define CUDA_CHECK(call)                                               \
   do {                                                                 \
@@ -16,12 +19,81 @@
     }                                                                  \
   } while (0)
 
-using namespace cute;
+template <typename T, int BLK_M, int BLK_N, typename ThreadLayoutA,
+          typename ThreadLayoutB>
+__global__ void mat_transpose_cute_reg_kernel(const T *pA, T *pB, int M, int N,
+                                              ThreadLayoutA tA,
+                                              ThreadLayoutB tB) {
+  int tx = threadIdx.x;
+  int bx = blockIdx.x, by = blockIdx.y;
 
-template <typename T, int BLK_M, int BLK_N, typename ThreadLayout>
-__global__ void mat_transpose_cute_row2col_naive_kernel(const T *pA, T *pB,
-                                                        int M, int N,
-                                                        ThreadLayout tAB) {
+  auto mA =
+      make_tensor(make_gmem_ptr(pA),
+                  make_layout(make_shape(M, N), GenRowMajor{}));  // (M, N)
+  auto mB =
+      make_tensor(make_gmem_ptr(pB),
+                  make_layout(make_shape(N, M), GenRowMajor{}));  // (N, M)
+
+  auto gA = local_tile(mA, make_shape(Int<BLK_M>{}, Int<BLK_N>{}),
+                       make_coord(bx, by));  // (BM, BN)
+  auto gB = local_tile(mB, make_shape(Int<BLK_N>{}, Int<BLK_M>{}),
+                       make_coord(by, bx));  // (BN, BM)
+  auto cA = local_tile(make_identity_tensor(mA.shape()),
+                       make_shape(Int<BLK_M>{}, Int<BLK_N>{}),
+                       make_coord(bx, by));  // (BM, BN)
+
+  Tensor tAgA = local_partition(gA, tA, tx);
+  Tensor tBgB = local_partition(gB, tB, tx);
+  Tensor tAcA = local_partition(cA, tA, tx);
+
+  Tensor tApA = make_tensor<bool>(tAcA.shape(), tAcA.stride());
+  CUTE_UNROLL
+  for (int i = 0; i < size<0>(tApA); i++) {
+    CUTE_UNROLL
+    for (int j = 0; j < size<1>(tApA); j++) {
+      tApA(i, j) = get<0>(tAcA(i, j)) < M && get<1>(tAcA(i, j)) < N;
+    }
+  }
+  copy_if(tApA, tAgA, tBgB);
+}
+
+void mat_transpose_cute_row2col_reg(torch::Tensor x, torch::Tensor y) {
+  const int BM = UNIT_BLK_SIZE;
+  const int BN = UNIT_BLK_SIZE;
+  const int M = x.size(0);
+  const int N = x.size(1);
+  auto tA = make_layout(make_shape(Int<BM>{}, Int<BN>{}), GenColMajor{});
+  auto tB = make_layout(make_shape(Int<BN>{}, Int<BM>{}), GenRowMajor{});
+  static_assert(size(tA) == size(tB));
+  dim3 block(size(tA));
+  dim3 grid((M + BM - 1) / BM, (N + BN - 1) / BN);
+  mat_transpose_cute_reg_kernel<float, BM, BN, decltype(tA), decltype(tB)>
+      <<<grid, block>>>(x.data_ptr<float>(), y.data_ptr<float>(), M, N, tA, tB);
+  CUDA_CHECK(cudaGetLastError());
+}
+
+void mat_transpose_cute_col2row_reg(torch::Tensor x, torch::Tensor y) {
+  const int BM = UNIT_BLK_SIZE;
+  const int BN = UNIT_BLK_SIZE;
+  const int M = x.size(0);
+  const int N = x.size(1);
+  auto tA = make_layout(make_shape(Int<BM>{}, Int<BN>{}), GenRowMajor{});
+  auto tB = make_layout(make_shape(Int<BN>{}, Int<BM>{}), GenColMajor{});
+  static_assert(size(tA) == size(tB));
+  dim3 block(size(tA));
+  dim3 grid((M + BM - 1) / BM, (N + BN - 1) / BN);
+  mat_transpose_cute_reg_kernel<float, BM, BN, decltype(tA), decltype(tB)>
+      <<<grid, block>>>(x.data_ptr<float>(), y.data_ptr<float>(), M, N, tA, tB);
+  CUDA_CHECK(cudaGetLastError());
+}
+
+template <typename T, int BLK_M, int BLK_N, typename ThreadLayoutA,
+          typename ThreadLayoutB, typename SmemLayoutA, typename SmemLayoutB>
+__global__ void mat_transpose_cute_smem_kernel(const T *pA, T *pB, int M, int N,
+                                               ThreadLayoutA tA,
+                                               ThreadLayoutB tB,
+                                               SmemLayoutA sA_layout,
+                                               SmemLayoutB sB_layout) {
   int tx = threadIdx.x;
   int bx = blockIdx.x, by = blockIdx.y;
 
@@ -44,19 +116,17 @@ __global__ void mat_transpose_cute_row2col_naive_kernel(const T *pA, T *pB,
                        make_coord(by, bx));  // (BN, BM)
 
   __shared__ T smem[BLK_M * BLK_N];
-  auto sA = make_tensor(
-      make_smem_ptr(smem),
-      make_layout(make_shape(BLK_M, BLK_N), GenRowMajor{}));  // (BM, BN)
-  auto sB = make_tensor(
-      make_smem_ptr(smem),
-      make_layout(make_shape(BLK_N, BLK_M), GenColMajor{}));  // (BN, BM)
+  auto sA = make_tensor(make_smem_ptr(smem),
+                        sA_layout);  // (BM, BN)
+  auto sB = make_tensor(make_smem_ptr(smem),
+                        sB_layout);  // (BN, BM)
 
-  Tensor tAgA = local_partition(gA, tAB, tx);
-  Tensor tBgB = local_partition(gB, tAB, tx);
-  Tensor tAsA = local_partition(sA, tAB, tx);
-  Tensor tBsB = local_partition(sB, tAB, tx);
-  Tensor tAcA = local_partition(cA, tAB, tx);
-  Tensor tBcB = local_partition(cB, tAB, tx);
+  Tensor tAgA = local_partition(gA, tA, tx);
+  Tensor tBgB = local_partition(gB, tB, tx);
+  Tensor tAsA = local_partition(sA, tA, tx);
+  Tensor tBsB = local_partition(sB, tB, tx);
+  Tensor tAcA = local_partition(cA, tA, tx);
+  Tensor tBcB = local_partition(cB, tB, tx);
 
   Tensor tApA = make_tensor<bool>(tAcA.shape(), tAcA.stride());
   Tensor tBpB = make_tensor<bool>(tBcB.shape(), tBcB.stride());
@@ -79,106 +149,109 @@ __global__ void mat_transpose_cute_row2col_naive_kernel(const T *pA, T *pB,
   copy_if(tBpB, tBsB, tBgB);
 }
 
-void mat_transpose_cute_row2col_naive(torch::Tensor x, torch::Tensor y) {
-  const int BM = 16;
-  const int BN = 16;
+constexpr int log2(int x) {
+  assert(x > 0);
+  return (x & (x - 1)) == 0 ? __builtin_ctz(x)
+                            : (throw "x is not a power of 2", 0);
+}
+
+void mat_transpose_cute_col_smem(torch::Tensor x, torch::Tensor y) {
+  const int BM = UNIT_BLK_SIZE;
+  const int BN = UNIT_BLK_SIZE;
   const int M = x.size(0);
   const int N = x.size(1);
-  auto tAB = make_layout(make_shape(Int<BM>{}, Int<BN>{}), GenRowMajor{});
-  dim3 block(size(tAB));
+  auto tA = make_layout(make_shape(Int<BM>{}, Int<BN>{}), GenColMajor{});
+  auto tB = make_layout(make_shape(Int<BN>{}, Int<BM>{}), GenColMajor{});
+  auto sA_layout = make_layout(make_shape(Int<BM>{}, Int<BN>{}), GenRowMajor{});
+  auto sB_layout = make_layout(make_shape(Int<BN>{}, Int<BM>{}), GenColMajor{});
+  static_assert(size(tA) == size(tB));
+  dim3 block(size(tA));
   dim3 grid((M + BM - 1) / BM, (N + BN - 1) / BN);
-  mat_transpose_cute_row2col_naive_kernel<float, BM, BN, decltype(tAB)>
-      <<<grid, block>>>(x.data_ptr<float>(), y.data_ptr<float>(), M, N, tAB);
+  mat_transpose_cute_smem_kernel<float, BM, BN, decltype(tA), decltype(tB),
+                                 decltype(sA_layout), decltype(sB_layout)>
+      <<<grid, block>>>(x.data_ptr<float>(), y.data_ptr<float>(), M, N, tA, tB,
+                        sA_layout, sB_layout);
   CUDA_CHECK(cudaGetLastError());
 }
 
-template <typename T, int BLK_M, int BLK_N, typename ThreadLayout, typename SmemLayout>
-__global__ void mat_transpose_cute_row2col_swizzled_kernel(const T *pA, T *pB,
-                                                        int M, int N,
-                                                        ThreadLayout tAB, SmemLayout smem_layout) {
-  int tx = threadIdx.x;
-  int bx = blockIdx.x, by = blockIdx.y;
-
-  auto mA =
-      make_tensor(make_gmem_ptr(pA),
-                  make_layout(make_shape(M, N), GenRowMajor{}));  // (M, N)
-  auto mB =
-      make_tensor(make_gmem_ptr(pB),
-                  make_layout(make_shape(N, M), GenRowMajor{}));  // (N, M)
-
-  auto gA = local_tile(mA, make_shape(Int<BLK_M>{}, Int<BLK_N>{}),
-                       make_coord(bx, by));  // (BM, BN)
-  auto gB = local_tile(mB, make_shape(Int<BLK_N>{}, Int<BLK_M>{}),
-                       make_coord(by, bx));  // (BN, BM)
-  auto cA = local_tile(make_identity_tensor(mA.shape()),
-                       make_shape(Int<BLK_M>{}, Int<BLK_N>{}),
-                       make_coord(bx, by));  // (BM, BN)
-  auto cB = local_tile(make_identity_tensor(mB.shape()),
-                       make_shape(Int<BLK_N>{}, Int<BLK_M>{}),
-                       make_coord(by, bx));  // (BN, BM)
-
-  __shared__ T smem[BLK_M * BLK_N];
-  auto sA = make_tensor(
-      make_smem_ptr(smem),
-      smem_layout);  // (BM, BN)
-  auto sB = make_tensor(
-      make_smem_ptr(smem),
-      smem_layout);  // (BN, BM)
-
-  Tensor tAgA = local_partition(gA, tAB, tx);
-  Tensor tBgB = local_partition(gB, tAB, tx);
-  Tensor tAsA = local_partition(sA, tAB, tx);
-  Tensor tBsB = local_partition(sB, tAB, tx);
-  Tensor tAcA = local_partition(cA, tAB, tx);
-  Tensor tBcB = local_partition(cB, tAB, tx);
-
-  Tensor tApA = make_tensor<bool>(tAcA.shape(), tAcA.stride());
-  Tensor tBpB = make_tensor<bool>(tBcB.shape(), tBcB.stride());
-  CUTE_UNROLL
-  for (int i = 0; i < size<0>(tApA); i++) {
-    CUTE_UNROLL
-    for (int j = 0; j < size<1>(tApA); j++) {
-      tApA(i, j) = get<0>(tAcA(i, j)) < M && get<1>(tAcA(i, j)) < N;
-    }
-  }
-  CUTE_UNROLL
-  for (int i = 0; i < size<0>(tBpB); i++) {
-    CUTE_UNROLL
-    for (int j = 0; j < size<1>(tBpB); j++) {
-      tBpB(i, j) = get<0>(tBcB(i, j)) < N && get<1>(tBcB(i, j)) < M;
-    }
-  }
-  copy_if(tApA, tAgA, tAsA);
-  __syncthreads();
-  copy_if(tBpB, tBsB, tBgB);
-}
-
-void mat_transpose_cute_row2col_swizzled(torch::Tensor x, torch::Tensor y) {
-  const int BM = 16;
-  const int BN = 16;
+void mat_transpose_cute_row_smem(torch::Tensor x, torch::Tensor y) {
+  const int BM = UNIT_BLK_SIZE;
+  const int BN = UNIT_BLK_SIZE;
   const int M = x.size(0);
   const int N = x.size(1);
-  auto tAB = make_layout(make_shape(Int<BM>{}, Int<BN>{}), GenRowMajor{});
-  dim3 block(size(tAB));
+  auto tA = make_layout(make_shape(Int<BM>{}, Int<BN>{}), GenRowMajor{});
+  auto tB = make_layout(make_shape(Int<BN>{}, Int<BM>{}), GenRowMajor{});
+  auto sA_layout = make_layout(make_shape(Int<BM>{}, Int<BN>{}), GenRowMajor{});
+  auto sB_layout = make_layout(make_shape(Int<BN>{}, Int<BM>{}), GenColMajor{});
+  static_assert(size(tA) == size(tB));
+  dim3 block(size(tA));
   dim3 grid((M + BM - 1) / BM, (N + BN - 1) / BN);
-  auto smem_layout = composition(
-    Swizzle<4, 0, 4>{},
-    make_layout(make_shape(Int<BN>{}, Int<BM>{}),
-                                         GenColMajor{}));
-  mat_transpose_cute_row2col_swizzled_kernel<float, BM, BN, decltype(tAB)>
-      <<<grid, block>>>(x.data_ptr<float>(), y.data_ptr<float>(), M, N, tAB, smem_layout);
+  mat_transpose_cute_smem_kernel<float, BM, BN, decltype(tA), decltype(tB),
+                                 decltype(sA_layout), decltype(sB_layout)>
+      <<<grid, block>>>(x.data_ptr<float>(), y.data_ptr<float>(), M, N, tA, tB,
+                        sA_layout, sB_layout);
   CUDA_CHECK(cudaGetLastError());
 }
 
+void mat_transpose_cute_col_smem_swizzled(torch::Tensor x, torch::Tensor y) {
+  const int BM = UNIT_BLK_SIZE;
+  const int BN = UNIT_BLK_SIZE;
+  const int M = x.size(0);
+  const int N = x.size(1);
+  auto tA = make_layout(make_shape(Int<BM>{}, Int<BN>{}), GenColMajor{});
+  auto tB = make_layout(make_shape(Int<BN>{}, Int<BM>{}), GenColMajor{});
+  const int S = log2(BM);
+  auto swizzle_func = Swizzle<S, 0, S>{};
+  auto sA_layout =
+      composition(swizzle_func,
+                  make_layout(make_shape(Int<BM>{}, Int<BN>{}), GenRowMajor{}));
+  auto sB_layout =
+      composition(swizzle_func,
+                  make_layout(make_shape(Int<BN>{}, Int<BM>{}), GenColMajor{}));
+  static_assert(size(tA) == size(tB));
+  dim3 block(size(tA));
+  dim3 grid((M + BM - 1) / BM, (N + BN - 1) / BN);
+  mat_transpose_cute_smem_kernel<float, BM, BN, decltype(tA), decltype(tB),
+                                 decltype(sA_layout), decltype(sB_layout)>
+      <<<grid, block>>>(x.data_ptr<float>(), y.data_ptr<float>(), M, N, tA, tB,
+                        sA_layout, sB_layout);
+  CUDA_CHECK(cudaGetLastError());
+}
+
+void mat_transpose_cute_row_smem_swizzled(torch::Tensor x, torch::Tensor y) {
+  const int BM = UNIT_BLK_SIZE;
+  const int BN = UNIT_BLK_SIZE;
+  const int M = x.size(0);
+  const int N = x.size(1);
+  auto tA = make_layout(make_shape(Int<BM>{}, Int<BN>{}), GenRowMajor{});
+  auto tB = make_layout(make_shape(Int<BN>{}, Int<BM>{}), GenRowMajor{});
+  const int S = log2(BM);
+  auto swizzle_func = Swizzle<S, 0, S>{};
+  auto sA_layout =
+      composition(swizzle_func,
+                  make_layout(make_shape(Int<BM>{}, Int<BN>{}), GenRowMajor{}));
+  auto sB_layout =
+      composition(swizzle_func,
+                  make_layout(make_shape(Int<BN>{}, Int<BM>{}), GenColMajor{}));
+  static_assert(size(tA) == size(tB));
+  dim3 block(size(tA));
+  dim3 grid((M + BM - 1) / BM, (N + BN - 1) / BN);
+  mat_transpose_cute_smem_kernel<float, BM, BN, decltype(tA), decltype(tB),
+                                 decltype(sA_layout), decltype(sB_layout)>
+      <<<grid, block>>>(x.data_ptr<float>(), y.data_ptr<float>(), M, N, tA, tB,
+                        sA_layout, sB_layout);
+  CUDA_CHECK(cudaGetLastError());
+}
 
 __host__ __device__ inline bool is_aligned_128(const void *ptr) {
   return (reinterpret_cast<uintptr_t>(ptr) & 0xF) == 0;
 }
 
 template <typename T, int BLK_M, int BLK_N, typename TiledCopyA,
-          typename TiledCopyB>
-__global__ void mat_transpose_cute_row2col_vectorized_kernel(
-    const T *pA, T *pB, int M, int N, TiledCopyA copy_a, TiledCopyB copy_b) {
+          typename TiledCopyB, typename SmemLayoutA, typename SmemLayoutB>
+__global__ void mat_transpose_cute_smem_vectorized_kernel(
+    const T *pA, T *pB, int M, int N, TiledCopyA copy_a, TiledCopyB copy_b,
+    SmemLayoutA sA_layout, SmemLayoutB sB_layout) {
   int tx = threadIdx.x;
   int bx = blockIdx.x, by = blockIdx.y;
 
@@ -195,12 +268,10 @@ __global__ void mat_transpose_cute_row2col_vectorized_kernel(
                        make_coord(by, bx));  // (BN, BM)
 
   __shared__ T smem[BLK_M * BLK_N];
-  auto sA = make_tensor(
-      make_smem_ptr(smem),
-      make_layout(make_shape(BLK_M, BLK_N), GenRowMajor{}));  // (BM, BN)
-  auto sB = make_tensor(
-      make_smem_ptr(smem),
-      make_layout(make_shape(BLK_N, BLK_M), GenColMajor{}));  // (BN, BM)
+  auto sA = make_tensor(make_smem_ptr(smem),
+                        sA_layout);  // (BM, BN)
+  auto sB = make_tensor(make_smem_ptr(smem),
+                        sB_layout);  // (BN, BM)
 
   auto thr_copy_a = copy_a.get_slice(tx);
   Tensor tAgA = thr_copy_a.partition_S(gA);
@@ -215,9 +286,90 @@ __global__ void mat_transpose_cute_row2col_vectorized_kernel(
   copy(copy_b, tBsB, tBgB);
 }
 
-void mat_transpose_cute_row2col_vectorized(torch::Tensor x, torch::Tensor y) {
-  const int BM = 16;
-  const int BN = 64;
+void mat_transpose_cute_row_cvectorized(torch::Tensor x, torch::Tensor y) {
+  const int BM = UNIT_BLK_SIZE * 4;
+  const int BN = UNIT_BLK_SIZE;
+  auto ptr_A = x.data_ptr<float>();
+  auto ptr_B = y.data_ptr<float>();
+  const int M = x.size(0);
+  const int N = x.size(1);
+
+  // sanity checks
+  assert(M % 4 == 0);
+  assert(N % 4 == 0);
+  static_assert(BM % 4 == 0);
+  static_assert(BN % 4 == 0);
+  assert(is_aligned_128(ptr_A));
+  assert(is_aligned_128(ptr_B));
+
+  auto tile_copy_a = make_tiled_copy(
+      Copy_Atom<AutoVectorizingCopy, float>{},
+      make_layout(make_shape(Int<BM / 4>{}, Int<BN>{}), GenRowMajor{}),
+      make_layout(make_shape(Int<4>{}, Int<1>{}), GenRowMajor{}));
+  auto tile_copy_b = make_tiled_copy(
+      Copy_Atom<AutoVectorizingCopy, float>{},
+      make_layout(make_shape(Int<BN>{}, Int<BM / 4>{}), GenRowMajor{}),
+      make_layout(make_shape(Int<1>{}, Int<4>{}), GenRowMajor{}));
+  auto sA_layout = make_layout(make_shape(Int<BM>{}, Int<BN>{}), GenRowMajor{});
+  auto sB_layout = make_layout(make_shape(Int<BN>{}, Int<BM>{}), GenColMajor{});
+
+  static_assert(size(tile_copy_a) == size(tile_copy_b));
+  dim3 block(size(tile_copy_a));
+  dim3 grid((M + BM - 1) / BM, (N + BN - 1) / BN);
+  mat_transpose_cute_smem_vectorized_kernel<
+      float, BM, BN, decltype(tile_copy_a), decltype(tile_copy_b),
+      decltype(sA_layout), decltype(sB_layout)><<<grid, block>>>(
+      ptr_A, ptr_B, M, N, tile_copy_a, tile_copy_b, sA_layout, sB_layout);
+  CUDA_CHECK(cudaGetLastError());
+}
+
+void mat_transpose_cute_row_cvectorized_swizzled(torch::Tensor x,
+                                                 torch::Tensor y) {
+  const int BM = UNIT_BLK_SIZE * 4;
+  const int BN = UNIT_BLK_SIZE;
+  auto ptr_A = x.data_ptr<float>();
+  auto ptr_B = y.data_ptr<float>();
+  const int M = x.size(0);
+  const int N = x.size(1);
+
+  // sanity checks
+  assert(M % 4 == 0);
+  assert(N % 4 == 0);
+  static_assert(BM % 4 == 0);
+  static_assert(BN % 4 == 0);
+  assert(is_aligned_128(ptr_A));
+  assert(is_aligned_128(ptr_B));
+
+  auto tile_copy_a = make_tiled_copy(
+      Copy_Atom<AutoVectorizingCopy, float>{},
+      make_layout(make_shape(Int<BM / 4>{}, Int<BN>{}), GenRowMajor{}),
+      make_layout(make_shape(Int<4>{}, Int<1>{}), GenRowMajor{}));
+  auto tile_copy_b = make_tiled_copy(
+      Copy_Atom<AutoVectorizingCopy, float>{},
+      make_layout(make_shape(Int<BN>{}, Int<BM / 4>{}), GenRowMajor{}),
+      make_layout(make_shape(Int<1>{}, Int<4>{}), GenRowMajor{}));
+  const int S = log2(BN);
+  auto swizzle_func = Swizzle<S, 0, S>{};
+  auto sA_layout =
+      composition(swizzle_func,
+                  make_layout(make_shape(Int<BM>{}, Int<BN>{}), GenRowMajor{}));
+  auto sB_layout =
+      composition(swizzle_func,
+                  make_layout(make_shape(Int<BN>{}, Int<BM>{}), GenColMajor{}));
+
+  static_assert(size(tile_copy_a) == size(tile_copy_b));
+  dim3 block(size(tile_copy_a));
+  dim3 grid((M + BM - 1) / BM, (N + BN - 1) / BN);
+  mat_transpose_cute_smem_vectorized_kernel<
+      float, BM, BN, decltype(tile_copy_a), decltype(tile_copy_b),
+      decltype(sA_layout), decltype(sB_layout)><<<grid, block>>>(
+      ptr_A, ptr_B, M, N, tile_copy_a, tile_copy_b, sA_layout, sB_layout);
+  CUDA_CHECK(cudaGetLastError());
+}
+
+void mat_transpose_cute_row_rvectorized(torch::Tensor x, torch::Tensor y) {
+  const int BM = UNIT_BLK_SIZE;
+  const int BN = UNIT_BLK_SIZE * 4;
   auto ptr_A = x.data_ptr<float>();
   auto ptr_B = y.data_ptr<float>();
   const int M = x.size(0);
@@ -239,12 +391,59 @@ void mat_transpose_cute_row2col_vectorized(torch::Tensor x, torch::Tensor y) {
       Copy_Atom<AutoVectorizingCopy, float>{},
       make_layout(make_shape(Int<BN / 4>{}, Int<BM>{}), GenRowMajor{}),
       make_layout(make_shape(Int<4>{}, Int<1>{}), GenRowMajor{}));
+  auto sA_layout = make_layout(make_shape(Int<BM>{}, Int<BN>{}), GenRowMajor{});
+  auto sB_layout = make_layout(make_shape(Int<BN>{}, Int<BM>{}), GenColMajor{});
 
   static_assert(size(tile_copy_a) == size(tile_copy_b));
   dim3 block(size(tile_copy_a));
   dim3 grid((M + BM - 1) / BM, (N + BN - 1) / BN);
-  mat_transpose_cute_row2col_vectorized_kernel<
-      float, BM, BN, decltype(tile_copy_a), decltype(tile_copy_b)>
-      <<<grid, block>>>(ptr_A, ptr_B, M, N, tile_copy_a, tile_copy_b);
+  mat_transpose_cute_smem_vectorized_kernel<
+      float, BM, BN, decltype(tile_copy_a), decltype(tile_copy_b),
+      decltype(sA_layout), decltype(sB_layout)><<<grid, block>>>(
+      ptr_A, ptr_B, M, N, tile_copy_a, tile_copy_b, sA_layout, sB_layout);
+  CUDA_CHECK(cudaGetLastError());
+}
+
+void mat_transpose_cute_row_rvectorized_swizzled(torch::Tensor x,
+                                                 torch::Tensor y) {
+  const int BM = UNIT_BLK_SIZE;
+  const int BN = UNIT_BLK_SIZE * 4;
+  auto ptr_A = x.data_ptr<float>();
+  auto ptr_B = y.data_ptr<float>();
+  const int M = x.size(0);
+  const int N = x.size(1);
+
+  // sanity checks
+  assert(M % 4 == 0);
+  assert(N % 4 == 0);
+  static_assert(BM % 4 == 0);
+  static_assert(BN % 4 == 0);
+  assert(is_aligned_128(ptr_A));
+  assert(is_aligned_128(ptr_B));
+
+  auto tile_copy_a = make_tiled_copy(
+      Copy_Atom<AutoVectorizingCopy, float>{},
+      make_layout(make_shape(Int<BM>{}, Int<BN / 4>{}), GenRowMajor{}),
+      make_layout(make_shape(Int<1>{}, Int<4>{}), GenRowMajor{}));
+  auto tile_copy_b = make_tiled_copy(
+      Copy_Atom<AutoVectorizingCopy, float>{},
+      make_layout(make_shape(Int<BN / 4>{}, Int<BM>{}), GenRowMajor{}),
+      make_layout(make_shape(Int<4>{}, Int<1>{}), GenRowMajor{}));
+  const int S = log2(BM);
+  auto swizzle_func = Swizzle<S, 0, S>{};
+  auto sA_layout =
+      composition(swizzle_func,
+                  make_layout(make_shape(Int<BM>{}, Int<BN>{}), GenRowMajor{}));
+  auto sB_layout =
+      composition(swizzle_func,
+                  make_layout(make_shape(Int<BN>{}, Int<BM>{}), GenColMajor{}));
+
+  static_assert(size(tile_copy_a) == size(tile_copy_b));
+  dim3 block(size(tile_copy_a));
+  dim3 grid((M + BM - 1) / BM, (N + BN - 1) / BN);
+  mat_transpose_cute_smem_vectorized_kernel<
+      float, BM, BN, decltype(tile_copy_a), decltype(tile_copy_b),
+      decltype(sA_layout), decltype(sB_layout)><<<grid, block>>>(
+      ptr_A, ptr_B, M, N, tile_copy_a, tile_copy_b, sA_layout, sB_layout);
   CUDA_CHECK(cudaGetLastError());
 }


### PR DESCRIPTION
Add CuTe implementation for mat-transpose, launch configurations and naming are synced with CUDA C implementations.